### PR TITLE
ci: enable playwright e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,35 +75,65 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v4
 
-  # e2e-tests:
-  #   name: Playwright E2E (Chromium)
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 25
-  #   needs: quality-checks
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 1
+  e2e-tests:
+    name: Playwright E2E (Chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: quality-checks
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:17
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: mattis_db
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd "pg_isready -U user -d mattis_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://user:password@127.0.0.1:5432/mattis_db
+      BASIC_AUTH_USERNAME: admin
+      BASIC_AUTH_PASSWORD: admin
+      BASIC_AUTH_USER_ID: 00000000-0000-7000-8000-000000000000
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-  #     - name: Setup Node.js 22.x
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 22.x
-  #         cache: npm
-  #         cache-dependency-path: |
-  #           package-lock.json
-  #           infra/package-lock.json
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            infra/package-lock.json
 
-  #     - name: Install dependencies
-  #       run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-  #     - name: Install Playwright browsers
-  #       run: npx playwright install --with-deps chromium
+      - name: Create environment file
+        run: |
+          cat <<EOF > .env
+          DATABASE_URL=${DATABASE_URL}
+          BASIC_AUTH_USERNAME=${BASIC_AUTH_USERNAME}
+          BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD}
+          BASIC_AUTH_USER_ID=${BASIC_AUTH_USER_ID}
+          EOF
 
-  #     - name: Run Playwright tests
-  #       env:
-  #         PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
-  #       run: npm run test:e2e
+      - name: Seed database
+        run: npm run seed
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   postgres:
     # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/aurorapostgresql-release-calendar.html
-    image: postgres:16.6
+    image: postgres:17
     environment:
       POSTGRES_USER: mattis
       POSTGRES_PASSWORD: mattis


### PR DESCRIPTION
## Summary
- enable the Playwright CI job with a PostgreSQL service
- seed the test database with the workflow environment configuration before running e2e tests
- update the PostgreSQL images in CI and docker compose to version 17

## Testing
- Not run


------
https://chatgpt.com/codex/tasks/task_e_68eb84bd9660833393fb4d7576804c0d