### PR TITLE
chore: use drizzle in seed script

### DIFF
--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,6 +1,10 @@
 import "dotenv/config";
-import { Client } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
 import { env } from "@/env";
+import * as schema from "@/lib/db/schema";
 
 interface PlayerSeed {
   key: string;
@@ -27,6 +31,11 @@ interface FettMattisSeed {
   createdAt: Date;
   createdBy: string;
 }
+
+type Schema = typeof schema;
+type SeedDb = NodePgDatabase<Schema>;
+type TransactionClient = Parameters<Parameters<SeedDb["transaction"]>[0]>[0];
+type DbExecutor = SeedDb | TransactionClient;
 
 interface PlayerRecord {
   id: string;
@@ -147,98 +156,84 @@ async function seed(): Promise<void> {
     throw new Error("DATABASE_URL must be set before running the seed script.");
   }
 
-  const client = new Client({ connectionString: databaseUrl });
-  await client.connect();
+  const pool = new Pool({ connectionString: databaseUrl });
+  const db = drizzle({
+    client: pool,
+    schema,
+    casing: "snake_case",
+  });
 
   writeLine(process.stdout, "Starting database seed...");
 
-  let transactionStarted = false;
-
   try {
-    await client.query("BEGIN");
-    transactionStarted = true;
+    await db.transaction(async (tx) => {
+      await resetTables(tx);
+      await ensureDevUser(tx);
+      const players = await insertPlayers(tx);
+      const rounds = await insertRounds(tx, players);
+      await insertFettMattis(tx, players, rounds);
+    });
 
-    await resetTables(client);
-    await ensureDevUser(client);
-    const players = await insertPlayers(client);
-    const rounds = await insertRounds(client, players);
-    await insertFettMattis(client, players, rounds);
-
-    await client.query("COMMIT");
     writeLine(process.stdout, "Database seed completed successfully.");
   } catch (error: unknown) {
-    if (transactionStarted) {
-      try {
-        await client.query("ROLLBACK");
-      } catch (rollbackError: unknown) {
-        writeLine(
-          process.stderr,
-          `Rollback failed: ${formatError(rollbackError)}`,
-        );
-      }
-    }
-
     writeLine(process.stderr, `Database seed failed: ${formatError(error)}`);
     process.exitCode = 1;
   } finally {
-    await client.end();
+    await pool.end();
   }
 }
 
-async function resetTables(client: Client): Promise<void> {
+async function resetTables(client: DbExecutor): Promise<void> {
   writeLine(process.stdout, "Clearing existing data...");
-  await client.query("DELETE FROM fettmattis");
-  await client.query("DELETE FROM round_loser");
-  await client.query("DELETE FROM round_participants");
-  await client.query("DELETE FROM rounds");
-  await client.query("DELETE FROM players");
-  await client.query("DELETE FROM users");
+  await client.delete(schema.fettmattis);
+  await client.delete(schema.roundLoser);
+  await client.delete(schema.roundParticipants);
+  await client.delete(schema.rounds);
+  await client.delete(schema.players);
+  await client.delete(schema.users);
 }
 
-async function ensureDevUser(client: Client): Promise<void> {
+async function ensureDevUser(client: DbExecutor): Promise<void> {
   const username = `dev-${devUserId.slice(0, 8)}`;
 
-  await client.query(
-    `
-      INSERT INTO users (id, username)
-      VALUES ($1, $2)
-      ON CONFLICT (id) DO UPDATE SET username = EXCLUDED.username, updated_at = NOW()
-    `,
-    [devUserId, username],
-  );
+  await client
+    .insert(schema.users)
+    .values({ id: devUserId, username })
+    .onConflictDoUpdate({
+      target: schema.users.id,
+      set: { username, updatedAt: sql`now()` },
+    });
 
   writeLine(process.stdout, `Ensured developer user ${username}.`);
 }
 
 async function insertPlayers(
-  client: Client,
+  client: DbExecutor,
 ): Promise<Map<string, PlayerRecord>> {
   writeLine(process.stdout, "Inserting players...");
   const playerMap = new Map<string, PlayerRecord>();
 
   for (const player of playerSeeds) {
-    const { rows } = await client.query<{ id: string; display_name: string }>(
-      `
-        INSERT INTO players (id, display_name, user_id, active)
-        VALUES ($1, $2, $3, $4)
-        RETURNING id, display_name
-      `,
-      [
-        player.id,
-        player.displayName,
-        player.userId ?? null,
-        player.active ?? true,
-      ],
-    );
+    const [created] = await client
+      .insert(schema.players)
+      .values({
+        id: player.id,
+        displayName: player.displayName,
+        userId: player.userId ?? null,
+        active: player.active ?? true,
+      })
+      .returning({
+        id: schema.players.id,
+        displayName: schema.players.displayName,
+      });
 
-    const [created] = rows;
     if (!created) {
       throw new Error(`Failed to insert player ${player.displayName}.`);
     }
 
     playerMap.set(player.key, {
       id: created.id,
-      displayName: created.display_name,
+      displayName: created.displayName,
     });
 
     writeLine(process.stdout, `  • ${player.displayName}`);
@@ -248,7 +243,7 @@ async function insertPlayers(
 }
 
 async function insertRounds(
-  client: Client,
+  client: DbExecutor,
   players: Map<string, PlayerRecord>,
 ): Promise<Map<string, RoundRecord>> {
   writeLine(process.stdout, "Recording rounds...");
@@ -272,31 +267,24 @@ async function insertRounds(
       );
     }
 
-    await client.query(
-      `
-        INSERT INTO rounds (id, created_by, created_at, deleted_at)
-        VALUES ($1, $2, $3, NULL)
-      `,
-      [round.id, round.createdBy, round.createdAt.toISOString()],
+    await client.insert(schema.rounds).values({
+      id: round.id,
+      createdBy: round.createdBy,
+      createdAt: round.createdAt,
+      deletedAt: null,
+    });
+
+    await client.insert(schema.roundParticipants).values(
+      participantIds.map((participantId) => ({
+        roundId: round.id,
+        playerId: participantId,
+      })),
     );
 
-    for (const participantId of participantIds) {
-      await client.query(
-        `
-          INSERT INTO round_participants (round_id, player_id)
-          VALUES ($1, $2)
-        `,
-        [round.id, participantId],
-      );
-    }
-
-    await client.query(
-      `
-        INSERT INTO round_loser (round_id, loser_id)
-        VALUES ($1, $2)
-      `,
-      [round.id, loser.id],
-    );
+    await client.insert(schema.roundLoser).values({
+      roundId: round.id,
+      loserId: loser.id,
+    });
 
     roundsMap.set(round.key, { id: round.id });
     writeLine(process.stdout, `  • ${round.label}`);
@@ -306,7 +294,7 @@ async function insertRounds(
 }
 
 async function insertFettMattis(
-  client: Client,
+  client: DbExecutor,
   players: Map<string, PlayerRecord>,
   rounds: Map<string, RoundRecord>,
 ): Promise<void> {
@@ -323,13 +311,13 @@ async function insertFettMattis(
       throw new Error(`Fettmattis round ${entry.round} not found.`);
     }
 
-    await client.query(
-      `
-        INSERT INTO fettmattis (id, player_id, created_by, created_at, revoked_at)
-        VALUES ($1, $2, $3, $4, NULL)
-      `,
-      [entry.id, player.id, entry.createdBy, entry.createdAt.toISOString()],
-    );
+    await client.insert(schema.fettmattis).values({
+      id: entry.id,
+      playerId: player.id,
+      createdBy: entry.createdBy,
+      createdAt: entry.createdAt,
+      revokedAt: null,
+    });
 
     writeLine(process.stdout, `  • ${player.displayName}`);
   }


### PR DESCRIPTION
## Summary
- replace manual SQL in the seed script with Drizzle ORM inserts and deletes
- ensure developer user upsert uses Drizzle on-conflict handling
- manage the seed transaction via Drizzle and close the pooled connection cleanly

## Testing
- npm run tsc

------
https://chatgpt.com/codex/tasks/task_e_68eb94e52a8c8333ba3343ca2cb2f4dd