### PR TITLE
Fix open-next build artifact upload

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -161,6 +161,7 @@ jobs:
           path: .open-next
           if-no-files-found: error
           retention-days: 3
+          include-hidden-files: true
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Summary
- allow the GitHub Actions artifact step to include the hidden `.open-next` build output so deployment can fetch it

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ede66d70108333a8399307a507a815