### PR TITLE
fix: checkout repo before terraform deploy

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -173,6 +173,8 @@ jobs:
     environment: production
     timeout-minutes: 30
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
## Summary
- check out the repository in the deploy job so Terraform commands have access to the IaC files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ede99235a4833389020c47cbe5ab62