### PR TITLE
Optimize Playwright E2E job in CI

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: mcr.microsoft.com/playwright:v1.47.2-jammy
+      image: mcr.microsoft.com/playwright:v1.56.0-noble
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -125,7 +125,6 @@ jobs:
     timeout-minutes: 15
     container:
       image: mcr.microsoft.com/playwright:v1.47.2-jammy
-      options: --user pwuser
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -140,7 +140,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      DATABASE_URL: postgresql://user:password@127.0.0.1:5432/mattis_db
+      DATABASE_URL: postgresql://user:password@postgres:5432/mattis_db
       BASIC_AUTH_USERNAME: admin
       BASIC_AUTH_PASSWORD: admin
       BASIC_AUTH_USER_ID: 00000000-0000-7000-8000-000000000000

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -123,6 +123,9 @@ jobs:
     name: End-to-end tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    container:
+      image: mcr.microsoft.com/playwright:v1.47.2-jammy
+      options: --user pwuser
     services:
       postgres:
         image: postgres:17
@@ -150,9 +153,6 @@ jobs:
 
       - name: Seed database
         run: npm run seed
-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
         run: npm run test:e2e


### PR DESCRIPTION
## Summary
- run the GitHub Actions end-to-end job inside the Playwright Docker image to reuse pre-installed browsers
- remove the redundant browser installation step to reduce CI setup time

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f0995928288333a134927d24cd51b0