### PR TITLE
fix: enforce ssl verification in neon database url

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -37,7 +37,7 @@ resource "neon_database" "production_database" {
 }
 
 locals {
-  database_url = "postgresql://${neon_role.production_app.name}:${neon_role.production_app.password}@${neon_endpoint.production.host}/${neon_database.production_database.name}"
+  database_url = "postgresql://${neon_role.production_app.name}:${neon_role.production_app.password}@${neon_endpoint.production.host}/${neon_database.production_database.name}?sslmode=verify-full"
 }
 
 ###########################


### PR DESCRIPTION
## Summary
- append `?sslmode=verify-full` to the Neon `DATABASE_URL` generated by Terraform to require secure connections

## Testing
- not run (terraform change)


------
https://chatgpt.com/codex/tasks/task_e_68f0af2ce1d4833382f219dddd648368