### PR TITLE
feat: add shared api contracts

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -172,12 +172,12 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      BETTER_AUTH_SECRET: replace-with-a-strong-secret
     steps:
       - *node-checkout
       - *node-setup
       - *node-install-dependencies
+      - name: Copy .env.example to .env
+        run: cp .env.example .env
       - name: Build and package Lambda function
         run: npm run build:lambda
       - name: Zip Lambda function

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -172,6 +172,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      BETTER_AUTH_SECRET: replace-with-a-strong-secret
     steps:
       - *node-checkout
       - *node-setup

--- a/src/app/api/fettmattis/[fettmattisId]/route.ts
+++ b/src/app/api/fettmattis/[fettmattisId]/route.ts
@@ -1,6 +1,5 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { createProblemResponse } from "@/lib/api/problem-details";
+import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { uuidSchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
 import {
@@ -26,10 +25,9 @@ export async function DELETE(
 
   const validation = uuidSchema.safeParse(fettmattisId);
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 }
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Fettmattis id is invalid.";
+    return badRequest(detail);
   }
 
   try {

--- a/src/app/api/fettmattis/route.ts
+++ b/src/app/api/fettmattis/route.ts
@@ -35,10 +35,10 @@ export async function POST(req: NextRequest) {
     const validatedData = FettMattisCreateSchema.safeParse(body);
 
     if (!validatedData.success) {
-      return NextResponse.json(
-        { error: validatedData.error.issues },
-        { status: 400 },
-      );
+      const detail =
+        validatedData.error.issues.at(0)?.message ??
+        "Request body validation failed.";
+      return badRequest(detail);
     }
 
     const { player_id: playerId } = validatedData.data;

--- a/src/app/api/leaderboard/fettmattis/route.ts
+++ b/src/app/api/leaderboard/fettmattis/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { createProblemResponse } from "@/lib/api/problem-details";
+import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { LeaderboardQuerySchema } from "@/lib/api/schemas";
 import { getFettMattisLeaderboard } from "@/lib/db-client";
 
@@ -11,10 +11,9 @@ export async function GET(req: Request) {
   const validation = LeaderboardQuerySchema.safeParse(query);
 
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 },
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Invalid leaderboard query.";
+    return badRequest(detail);
   }
 
   const requestedYear = validation.data.year;

--- a/src/app/api/leaderboard/regular/route.ts
+++ b/src/app/api/leaderboard/regular/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { createProblemResponse } from "@/lib/api/problem-details";
+import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { LeaderboardQuerySchema } from "@/lib/api/schemas";
 import { getRegularLeaderboard } from "@/lib/db-client";
 
@@ -11,10 +11,9 @@ export async function GET(req: Request) {
   const validation = LeaderboardQuerySchema.safeParse(query);
 
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 },
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Invalid leaderboard query.";
+    return badRequest(detail);
   }
 
   const requestedYear = validation.data.year;

--- a/src/app/api/players/[playerId]/route.ts
+++ b/src/app/api/players/[playerId]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { toPlayerResponse } from "@/lib/api/response-helpers";
 import { PlayerUpdateSchema, uuidSchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
@@ -17,10 +18,9 @@ export async function GET(
 
   const validation = uuidSchema.safeParse(playerId);
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 },
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Player id is invalid.";
+    return badRequest(detail);
   }
 
   try {
@@ -29,20 +29,17 @@ export async function GET(
     return NextResponse.json(toPlayerResponse(player));
   } catch (error) {
     if (error instanceof NotFoundError) {
-      return NextResponse.json(
-        {
-          type: "about:blank",
-          title: "Not Found",
-          status: 404,
-          detail: error.message,
-        },
-        { status: 404 },
-      );
+      return createProblemResponse({
+        status: 404,
+        title: "Not Found",
+        detail: error.message,
+      });
     }
-    return NextResponse.json(
-      { type: "about:blank", title: "Internal Server Error", status: 500 },
-      { status: 500 },
-    );
+    return createProblemResponse({
+      status: 500,
+      title: "Internal Server Error",
+      detail: "Internal Server Error",
+    });
   }
 }
 
@@ -54,23 +51,18 @@ export async function PUT(
 
   const validation = uuidSchema.safeParse(playerId);
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 },
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Player id is invalid.";
+    return badRequest(detail);
   }
 
   const userId = await resolveRequestUserId(req.headers);
   if (!userId) {
-    return NextResponse.json(
-      {
-        type: "about:blank",
-        title: "Unauthorized",
-        status: 401,
-        detail: "Authentication required.",
-      },
-      { status: 401 },
-    );
+    return createProblemResponse({
+      status: 401,
+      title: "Unauthorized",
+      detail: "Authentication required.",
+    });
   }
 
   try {
@@ -78,10 +70,10 @@ export async function PUT(
     const bodyValidation = PlayerUpdateSchema.safeParse(body);
 
     if (!bodyValidation.success) {
-      return NextResponse.json(
-        { error: bodyValidation.error.issues },
-        { status: 400 },
-      );
+      const detail =
+        bodyValidation.error.issues.at(0)?.message ??
+        "Request body validation failed.";
+      return badRequest(detail);
     }
 
     const { display_name, active } = bodyValidation.data;
@@ -94,30 +86,23 @@ export async function PUT(
     return NextResponse.json(toPlayerResponse(updatedPlayer));
   } catch (error) {
     if (error instanceof NotFoundError) {
-      return NextResponse.json(
-        {
-          type: "about:blank",
-          title: "Not Found",
-          status: 404,
-          detail: error.message,
-        },
-        { status: 404 },
-      );
+      return createProblemResponse({
+        status: 404,
+        title: "Not Found",
+        detail: error.message,
+      });
     }
     if (error instanceof ConflictError) {
-      return NextResponse.json(
-        {
-          type: "about:blank",
-          title: "Conflict",
-          status: 409,
-          detail: error.message,
-        },
-        { status: 409 },
-      );
+      return createProblemResponse({
+        status: 409,
+        title: "Conflict",
+        detail: error.message,
+      });
     }
-    return NextResponse.json(
-      { type: "about:blank", title: "Internal Server Error", status: 500 },
-      { status: 500 },
-    );
+    return createProblemResponse({
+      status: 500,
+      title: "Internal Server Error",
+      detail: "Internal Server Error",
+    });
   }
 }

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { createProblemResponse } from "@/lib/api/problem-details";
+import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { toPlayerResponse } from "@/lib/api/response-helpers";
 import { PlayerCreateSchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
@@ -21,10 +21,10 @@ export async function POST(req: Request) {
     const validation = PlayerCreateSchema.safeParse(body);
 
     if (!validation.success) {
-      return NextResponse.json(
-        { error: validation.error.issues },
-        { status: 400 },
-      );
+      const detail =
+        validation.error.issues.at(0)?.message ??
+        "Request body validation failed.";
+      return badRequest(detail);
     }
 
     const { display_name } = validation.data;
@@ -37,15 +37,11 @@ export async function POST(req: Request) {
     return NextResponse.json(toPlayerResponse(newPlayer), { status: 201 });
   } catch (error) {
     if (error instanceof ConflictError) {
-      return NextResponse.json(
-        {
-          type: "about:blank",
-          title: "Conflict",
-          status: 409,
-          detail: error.message,
-        },
-        { status: 409 },
-      );
+      return createProblemResponse({
+        status: 409,
+        title: "Conflict",
+        detail: error.message,
+      });
     }
 
     return createProblemResponse({

--- a/src/app/api/rounds/[roundId]/route.ts
+++ b/src/app/api/rounds/[roundId]/route.ts
@@ -21,10 +21,9 @@ export async function GET(
 
   const validation = uuidSchema.safeParse(roundId);
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 }
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Round id is invalid.";
+    return badRequest(detail);
   }
 
   try {
@@ -64,10 +63,9 @@ export async function PUT(
 
   const validation = uuidSchema.safeParse(roundId);
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 }
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Round id is invalid.";
+    return badRequest(detail);
   }
 
   let body: unknown;
@@ -79,10 +77,10 @@ export async function PUT(
 
   const parsedBody = RoundUpdateSchema.safeParse(body);
   if (!parsedBody.success) {
-    return NextResponse.json(
-      { error: parsedBody.error.issues },
-      { status: 400 }
-    );
+    const detail =
+      parsedBody.error.issues.at(0)?.message ??
+      "Request body validation failed.";
+    return badRequest(detail);
   }
 
   try {
@@ -139,10 +137,9 @@ export async function DELETE(
 
   const validation = uuidSchema.safeParse(roundId);
   if (!validation.success) {
-    return NextResponse.json(
-      { error: validation.error.issues },
-      { status: 400 }
-    );
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Round id is invalid.";
+    return badRequest(detail);
   }
 
   try {

--- a/src/app/api/rounds/route.ts
+++ b/src/app/api/rounds/route.ts
@@ -31,10 +31,10 @@ export async function POST(req: NextRequest) {
     const validatedData = RoundCreateSchema.safeParse(body);
 
     if (!validatedData.success) {
-      return NextResponse.json(
-        { error: validatedData.error.issues },
-        { status: 400 },
-      );
+      const detail =
+        validatedData.error.issues.at(0)?.message ??
+        "Request body validation failed.";
+      return badRequest(detail);
     }
 
     const { participant_ids, loser_id } = validatedData.data;

--- a/src/app/players/players-client.tsx
+++ b/src/app/players/players-client.tsx
@@ -26,12 +26,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import {
   fetchPlayers,
   PLAYERS_QUERY_KEY,
-  type PlayersApiRecord,
-  type PlayerUpdatePayload,
+  type Player,
+  type PlayerUpdate,
   resolvePlayerError,
   updatePlayer,
 } from "@/lib/api/players-client";
-import type { PlayerCreate } from "@/lib/api/schemas";
+import { type PlayerCreate, PlayerSchema } from "@/lib/api/schemas";
 
 const ROSTER_SKELETON_KEYS = [
   "roster-row-1",
@@ -51,18 +51,14 @@ export default function PlayersClientPage() {
   const { getAuthHeader } = useAuth();
   const authHeader = getAuthHeader();
 
-  const playersQuery = useQuery<PlayersApiRecord[]>({
+  const playersQuery = useQuery<Player[]>({
     queryKey: PLAYERS_QUERY_KEY,
     queryFn: fetchPlayers,
   });
 
-  const players: PlayersApiRecord[] = playersQuery.data ?? [];
+  const players: Player[] = playersQuery.data ?? [];
 
-  const createPlayerMutation = useMutation<
-    PlayersApiRecord,
-    Error,
-    PlayerCreate
-  >({
+  const createPlayerMutation = useMutation<Player, Error, PlayerCreate>({
     mutationFn: async (payload) => {
       if (!authHeader) {
         throw new Error("Innlogging kreves for å opprette en spiller.");
@@ -81,7 +77,14 @@ export default function PlayersClientPage() {
         throw new Error(detail ?? "Kunne ikke opprette spiller");
       }
 
-      return (await response.json()) as PlayersApiRecord;
+      const responseBody = (await response.json()) as unknown;
+      const parsed = PlayerSchema.safeParse(responseBody);
+
+      if (!parsed.success) {
+        throw new Error("Kunne ikke bekrefte den nye spilleren.");
+      }
+
+      return parsed.data;
     },
     onSuccess: async () => {
       setMessage("Spiller lagt til i troppen. Velkommen!");
@@ -106,9 +109,9 @@ export default function PlayersClientPage() {
   };
 
   const updatePlayerMutation = useMutation<
-    PlayersApiRecord,
+    Player,
     Error,
-    { playerId: string; payload: PlayerUpdatePayload }
+    { playerId: string; payload: PlayerUpdate }
   >({
     mutationFn: async ({ playerId, payload }) => {
       if (!authHeader) {
@@ -122,10 +125,7 @@ export default function PlayersClientPage() {
     },
   });
 
-  const handlePlayerUpdate = async (
-    player: PlayersApiRecord,
-    payload: PlayerUpdatePayload,
-  ) => {
+  const handlePlayerUpdate = async (player: Player, payload: PlayerUpdate) => {
     setRosterMessage(null);
     setRosterError(null);
     setUpdatingPlayerId(player.id);

--- a/src/app/rounds/rounds-client.tsx
+++ b/src/app/rounds/rounds-client.tsx
@@ -18,49 +18,25 @@ import { useAuth } from "@/contexts/AuthContext";
 import {
   fetchPlayers,
   PLAYERS_QUERY_KEY,
-  type PlayersApiRecord,
+  type Player,
 } from "@/lib/api/players-client";
 import {
   fetchLatestRound,
   LATEST_ROUND_QUERY_KEY,
-  type RoundApiRecord,
+  type Round,
 } from "@/lib/api/rounds-client";
-import type { FettMattisCreate, RoundCreate } from "@/lib/api/schemas";
+import {
+  type FettMattisCreate,
+  ProblemDetailsSchema,
+  type RoundCreate,
+} from "@/lib/api/schemas";
 
-interface ProblemDetailPayload {
-  readonly detail?: unknown;
-  readonly error?: unknown;
-}
-
-const isMessageRecord = (value: unknown): value is { message: string } => {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  return typeof (value as { message?: unknown }).message === "string";
-};
-
-const extractErrorDetail = (body: unknown): string | undefined => {
-  if (typeof body !== "object" || body === null) {
+const resolveProblemDetail = (body: unknown): string | undefined => {
+  const parsed = ProblemDetailsSchema.safeParse(body);
+  if (!parsed.success) {
     return undefined;
   }
-
-  const candidate = body as ProblemDetailPayload;
-
-  if (typeof candidate.detail === "string") {
-    return candidate.detail;
-  }
-
-  if (Array.isArray(candidate.error)) {
-    const errors = candidate.error as unknown[];
-    for (const entry of errors) {
-      if (isMessageRecord(entry)) {
-        return entry.message;
-      }
-    }
-  }
-
-  return undefined;
+  return parsed.data.detail;
 };
 
 const ROUND_FORM_SKELETON_KEYS = [
@@ -83,16 +59,16 @@ export default function RoundsClientPage() {
   const { getAuthHeader } = useAuth();
   const authHeader = getAuthHeader();
 
-  const playersQuery = useQuery<PlayersApiRecord[]>({
+  const playersQuery = useQuery<Player[]>({
     queryKey: PLAYERS_QUERY_KEY,
     queryFn: fetchPlayers,
   });
 
-  const players: PlayersApiRecord[] = playersQuery.data ?? [];
+  const players: Player[] = playersQuery.data ?? [];
   const isPlayersLoading = playersQuery.isLoading;
   const isPlayersFetching = playersQuery.isFetching;
 
-  const latestRoundQuery = useQuery<RoundApiRecord | null>({
+  const latestRoundQuery = useQuery<Round | null>({
     queryKey: LATEST_ROUND_QUERY_KEY,
     queryFn: fetchLatestRound,
   });
@@ -158,7 +134,7 @@ export default function RoundsClientPage() {
 
       if (!response.ok) {
         const body: unknown = await response.json();
-        const detail = extractErrorDetail(body);
+        const detail = resolveProblemDetail(body);
         throw new Error(detail ?? "Kunne ikke lagre runden.");
       }
     },
@@ -189,7 +165,7 @@ export default function RoundsClientPage() {
 
       if (!response.ok) {
         const body: unknown = await response.json();
-        const detail = extractErrorDetail(body);
+        const detail = resolveProblemDetail(body);
         throw new Error(detail ?? "Kunne ikke tildele en Fettmattis.");
       }
     },

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,13 @@ import {
   useState,
 } from "react";
 
+import {
+  type AuthSession,
+  AuthSessionResponseSchema,
+  EmailPasswordSignInResponseSchema,
+  ProblemDetailsSchema,
+} from "@/lib/api/schemas";
+
 interface AuthUser {
   id: string;
   email: string;
@@ -27,87 +34,6 @@ interface AuthContextType {
   getAuthHeader: () => Record<string, string> | null;
 }
 
-interface SessionResponse {
-  readonly session: {
-    token: string;
-    expiresAt?: string;
-    id?: string;
-  };
-  readonly user: {
-    id: string;
-    email: string;
-    name: string | null;
-  };
-}
-
-function normalizeSessionPayload(payload: unknown): SessionResponse | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-
-  const raw = payload as Record<string, unknown>;
-  const userCandidate = raw.user;
-
-  if (!userCandidate || typeof userCandidate !== "object") {
-    return null;
-  }
-
-  const user = userCandidate as {
-    id?: unknown;
-    email?: unknown;
-    name?: unknown;
-  };
-
-  if (typeof user.id !== "string" || typeof user.email !== "string") {
-    return null;
-  }
-
-  const sessionCandidate = raw.session;
-  let sessionToken: string | null = null;
-
-  if (typeof raw.token === "string" && raw.token) {
-    sessionToken = raw.token;
-  } else if (
-    sessionCandidate &&
-    typeof sessionCandidate === "object" &&
-    typeof (sessionCandidate as { token?: unknown }).token === "string"
-  ) {
-    sessionToken = (sessionCandidate as { token: string }).token;
-  }
-
-  if (!sessionToken) {
-    return null;
-  }
-
-  const session =
-    sessionCandidate && typeof sessionCandidate === "object"
-      ? {
-          token: sessionToken,
-          expiresAt:
-            typeof (sessionCandidate as { expiresAt?: unknown }).expiresAt ===
-            "string"
-              ? (sessionCandidate as { expiresAt: string }).expiresAt
-              : undefined,
-          id:
-            typeof (sessionCandidate as { id?: unknown }).id === "string"
-              ? (sessionCandidate as { id: string }).id
-              : undefined,
-        }
-      : { token: sessionToken };
-
-  return {
-    session,
-    user: {
-      id: user.id,
-      email: user.email,
-      name:
-        typeof user.name === "string" && user.name.length > 0
-          ? user.name
-          : null,
-    },
-  };
-}
-
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 interface AuthProviderProps {
@@ -120,7 +46,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const applySession = useCallback((payload: SessionResponse | null) => {
+  const applySession = useCallback((payload: AuthSession | null) => {
     if (!payload) {
       setUser(null);
       setToken(null);
@@ -151,7 +77,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       const data = await response.json();
-      applySession(normalizeSessionPayload(data));
+      const parsed = AuthSessionResponseSchema.safeParse(data);
+      applySession(parsed.success ? parsed.data : null);
     } catch (refreshError) {
       applySession(null);
       setError(
@@ -191,25 +118,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
             body = null;
           }
 
+          const problem = ProblemDetailsSchema.safeParse(body);
           const message =
-            body &&
-            typeof body === "object" &&
-            body !== null &&
-            "message" in body
-              ? (body as { message?: string }).message ??
-                "Feil e-post eller passord."
-              : "Feil e-post eller passord.";
+            (problem.success && problem.data.detail) ||
+            "Feil e-post eller passord.";
           throw new Error(message);
         }
 
         const data = await response.json();
-        const sessionPayload = normalizeSessionPayload(data);
+        const parsed = EmailPasswordSignInResponseSchema.safeParse(data);
 
-        if (!sessionPayload) {
+        if (!parsed.success) {
           throw new Error("Feil e-post eller passord.");
         }
 
-        applySession(sessionPayload);
+        applySession({
+          session: { token: parsed.data.token },
+          user: parsed.data.user,
+        });
       } catch (loginError) {
         applySession(null);
         setError(

--- a/src/lib/api/players-client.ts
+++ b/src/lib/api/players-client.ts
@@ -1,19 +1,17 @@
 import type { QueryKey } from "@tanstack/react-query";
 
-export interface PlayersApiRecord {
-  id: string;
-  display_name: string;
-  active: boolean;
-}
-
-export interface PlayerUpdatePayload {
-  display_name?: string;
-  active?: boolean;
-}
+import {
+  type Player,
+  PlayerSchema,
+  PlayersResponseSchema,
+  type PlayerUpdate,
+  PlayerUpdateSchema,
+  ProblemDetailsSchema,
+} from "./schemas";
 
 export const PLAYERS_QUERY_KEY = ["players"] as const satisfies QueryKey;
 
-export async function fetchPlayers(): Promise<PlayersApiRecord[]> {
+export async function fetchPlayers(): Promise<Player[]> {
   const response = await fetch("/api/players", {
     cache: "no-store",
   });
@@ -24,51 +22,41 @@ export async function fetchPlayers(): Promise<PlayersApiRecord[]> {
     );
   }
 
-  return (await response.json()) as PlayersApiRecord[];
+  const payload = (await response.json()) as unknown;
+  const parsed = PlayersResponseSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new Error("Received an invalid response when loading players.");
+  }
+
+  return parsed.data;
 }
 
 export const resolvePlayerError = (payload: unknown): string | undefined => {
-  if (typeof payload !== "object" || payload === null) {
-    return undefined;
-  }
+  const parsedProblem = ProblemDetailsSchema.safeParse(payload);
 
-  const candidate = payload as {
-    error?: unknown;
-    detail?: unknown;
-  };
-
-  if (Array.isArray(candidate.error)) {
-    for (const issue of candidate.error) {
-      if (
-        typeof issue === "object" &&
-        issue !== null &&
-        "message" in issue &&
-        typeof (issue as { message?: unknown }).message === "string"
-      ) {
-        return (issue as { message?: string }).message;
-      }
-    }
-  }
-
-  if (typeof candidate.detail === "string") {
-    return candidate.detail;
+  if (parsedProblem.success) {
+    return parsedProblem.data.detail;
   }
 
   return undefined;
 };
 
+export type { Player, PlayerUpdate } from "./schemas";
+
 export async function updatePlayer(
   playerId: string,
-  payload: PlayerUpdatePayload,
+  update: PlayerUpdate,
   authHeader?: Record<string, string> | null,
-): Promise<PlayersApiRecord> {
+): Promise<Player> {
+  const parsedPayload = PlayerUpdateSchema.parse(update);
   const response = await fetch(`/api/players/${playerId}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
       ...(authHeader ?? {}),
     },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(parsedPayload),
   });
 
   if (!response.ok) {
@@ -82,5 +70,12 @@ export async function updatePlayer(
     throw new Error(detail ?? "We couldn't update the player right now.");
   }
 
-  return (await response.json()) as PlayersApiRecord;
+  const responseBody = (await response.json()) as unknown;
+  const parsed = PlayerSchema.safeParse(responseBody);
+
+  if (!parsed.success) {
+    throw new Error("Received an invalid response when updating the player.");
+  }
+
+  return parsed.data;
 }

--- a/src/lib/api/response-helpers.ts
+++ b/src/lib/api/response-helpers.ts
@@ -4,22 +4,15 @@ import type {
   RoundRecord,
 } from "@/lib/db-client";
 
+import type { Player, Round } from "./schemas";
+
 export type PlayerResponseInput =
   | Pick<PlayerRecord, "id" | "displayName" | "active">
   | RoundParticipantRecord;
 
-export interface PlayerResponse {
-  id: string;
-  display_name: string;
-  active: boolean;
-}
+export type PlayerResponse = Player;
 
-export interface RoundResponse {
-  id: string;
-  created_at: string;
-  participants: PlayerResponse[];
-  loser: PlayerResponse;
-}
+export type RoundResponse = Round;
 
 export function toPlayerResponse(player: PlayerResponseInput): PlayerResponse {
   return {

--- a/src/lib/api/rounds-client.ts
+++ b/src/lib/api/rounds-client.ts
@@ -1,42 +1,13 @@
 import type { QueryKey } from "@tanstack/react-query";
-import { z } from "zod";
 
-import { PlayerSchema } from "@/lib/api/schemas";
-
-export interface RoundParticipantApiRecord {
-  id: string;
-  display_name: string;
-  active: boolean;
-}
-
-export interface RoundApiRecord {
-  id: string;
-  created_at: string;
-  participants: RoundParticipantApiRecord[];
-  loser: RoundParticipantApiRecord;
-}
+import { LatestRoundResponseSchema, type Round } from "@/lib/api/schemas";
 
 export const LATEST_ROUND_QUERY_KEY = [
   "rounds",
   "latest",
 ] as const satisfies QueryKey;
 
-const RoundParticipantSchema = PlayerSchema.pick({
-  id: true,
-  display_name: true,
-  active: true,
-});
-
-const LatestRoundSchema = z
-  .object({
-    id: z.string(),
-    created_at: z.string(),
-    participants: RoundParticipantSchema.array(),
-    loser: RoundParticipantSchema,
-  })
-  .nullable();
-
-export async function fetchLatestRound(): Promise<RoundApiRecord | null> {
+export async function fetchLatestRound(): Promise<Round | null> {
   const response = await fetch("/api/rounds/latest", {
     cache: "no-store",
   });
@@ -48,7 +19,7 @@ export async function fetchLatestRound(): Promise<RoundApiRecord | null> {
   }
 
   const payload = (await response.json()) as unknown;
-  const parsed = LatestRoundSchema.safeParse(payload);
+  const parsed = LatestRoundResponseSchema.safeParse(payload);
 
   if (!parsed.success) {
     throw new Error("Received an invalid response when loading latest round.");
@@ -56,3 +27,5 @@ export async function fetchLatestRound(): Promise<RoundApiRecord | null> {
 
   return parsed.data;
 }
+
+export type { Round } from "@/lib/api/schemas";

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -11,6 +11,58 @@ export const uuidSchema = z.string().refine(
   { message: "Must be a valid UUID." },
 );
 
+const isoDateTimeSchema = z.string().datetime({ offset: true });
+
+// --- Authentication Schemas ---
+
+export const AuthUserSchema = z.object({
+  id: uuidSchema,
+  email: z.string().email(),
+  name: z.string().nullable().optional(),
+  image: z.string().url().nullable().optional(),
+  emailVerified: z.boolean().optional(),
+  createdAt: isoDateTimeSchema.optional(),
+  updatedAt: isoDateTimeSchema.optional(),
+});
+
+export const AuthSessionDataSchema = z.object({
+  token: z.string(),
+  expiresAt: isoDateTimeSchema.optional(),
+  id: z.string().optional(),
+  createdAt: isoDateTimeSchema.optional(),
+  updatedAt: isoDateTimeSchema.optional(),
+});
+
+export const AuthSessionSchema = z.object({
+  session: AuthSessionDataSchema,
+  user: AuthUserSchema,
+});
+
+export const AuthSessionResponseSchema = z.union([
+  AuthSessionSchema,
+  z.null(),
+]);
+
+export const EmailPasswordSignInRequestSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+  callbackURL: z.string().url().optional(),
+  rememberMe: z.boolean().optional(),
+});
+
+export const EmailPasswordSignInResponseSchema = z.object({
+  redirect: z.boolean(),
+  token: z.string(),
+  url: z.string().url().nullable().optional(),
+  user: AuthUserSchema,
+});
+
+export const SignOutResponseSchema = z.object({
+  success: z.boolean(),
+});
+
+// --- Player Schemas ---
+
 export const PlayerSchema = z.object({
   id: uuidSchema,
   display_name: z.string().min(1, "Display name cannot be empty."),
@@ -26,7 +78,16 @@ export const PlayerUpdateSchema = z.object({
   active: z.boolean().optional(),
 });
 
+export const PlayersResponseSchema = PlayerSchema.array();
+
 // --- Round Schemas ---
+
+export const RoundSchema = z.object({
+  id: uuidSchema,
+  created_at: isoDateTimeSchema,
+  participants: PlayerSchema.array(),
+  loser: PlayerSchema,
+});
 
 export const RoundCreateSchema = z
   .object({
@@ -61,12 +122,24 @@ export const RoundUpdateSchema = z
     },
   );
 
+export const RoundListResponseSchema = RoundSchema.array();
+export const LatestRoundResponseSchema = RoundSchema.nullable();
+
 // --- FettMattis Schemas ---
+
+export const FettMattisSchema = z.object({
+  id: uuidSchema,
+  player: PlayerSchema,
+  round_id: uuidSchema.nullish(),
+  created_at: isoDateTimeSchema,
+});
 
 export const FettMattisCreateSchema = z.object({
   player_id: uuidSchema,
   round_id: uuidSchema.optional(),
 });
+
+export const FettMattisListResponseSchema = FettMattisSchema.array();
 
 // --- Leaderboard Schemas ---
 
@@ -81,21 +154,59 @@ export const LeaderboardQuerySchema = z.object({
     .optional(),
 });
 
+export const RegularLeaderboardItemSchema = z.object({
+  player: PlayerSchema,
+  rank: z.number().int(),
+  loss_percentage: z.number(),
+  participation_count: z.number().int(),
+  loss_count: z.number().int(),
+});
+
+export const FettmattisLeaderboardItemSchema = z.object({
+  player: PlayerSchema,
+  rank: z.number().int(),
+  fettmattis_count: z.number().int(),
+});
+
+export const RegularLeaderboardResponseSchema =
+  RegularLeaderboardItemSchema.array();
+export const FettmattisLeaderboardResponseSchema =
+  FettmattisLeaderboardItemSchema.array();
+
 // --- Utility Schemas ---
 
 export const ProblemDetailsSchema = z.object({
-  type: z.url().default("about:blank"),
+  type: z.string().url().or(z.literal("about:blank")),
   title: z.string(),
   status: z.number().int().min(400).max(599),
   detail: z.string().optional(),
-  instance: z.url().optional(),
+  instance: z.string().url().optional(),
 });
 
-// Export types
+// --- Exported Types ---
+
+export type AuthUser = z.infer<typeof AuthUserSchema>;
+export type AuthSessionData = z.infer<typeof AuthSessionDataSchema>;
+export type AuthSession = z.infer<typeof AuthSessionSchema>;
+export type EmailPasswordSignInRequest = z.infer<
+  typeof EmailPasswordSignInRequestSchema
+>;
+export type EmailPasswordSignInResponse = z.infer<
+  typeof EmailPasswordSignInResponseSchema
+>;
+export type SignOutResponse = z.infer<typeof SignOutResponseSchema>;
 export type Player = z.infer<typeof PlayerSchema>;
 export type PlayerCreate = z.infer<typeof PlayerCreateSchema>;
 export type PlayerUpdate = z.infer<typeof PlayerUpdateSchema>;
+export type Round = z.infer<typeof RoundSchema>;
 export type RoundCreate = z.infer<typeof RoundCreateSchema>;
 export type RoundUpdate = z.infer<typeof RoundUpdateSchema>;
+export type FettMattis = z.infer<typeof FettMattisSchema>;
 export type FettMattisCreate = z.infer<typeof FettMattisCreateSchema>;
-export type LeaderboardQuery = z.infer<typeof LeaderboardQuerySchema>;
+export type RegularLeaderboardItem = z.infer<
+  typeof RegularLeaderboardItemSchema
+>;
+export type FettmattisLeaderboardItem = z.infer<
+  typeof FettmattisLeaderboardItemSchema
+>;
+export type ProblemDetails = z.infer<typeof ProblemDetailsSchema>;

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -1,7 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
-
 import { config, env } from "@/env";
 import { db } from "@/lib/db/db";
 import * as schema from "@/lib/db/schema";

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,30 +1,12 @@
+import {
+  FettmattisLeaderboardResponseSchema,
+  RegularLeaderboardResponseSchema,
+} from "@/lib/api/schemas";
 import type {
   FettmattisLeaderboard,
   LeaderboardScope,
   RegularLeaderboard,
 } from "@/lib/leaderboard-types";
-
-interface RegularLeaderboardResponse {
-  rank?: number | null;
-  loss_percentage: number;
-  participation_count: number;
-  loss_count: number;
-  player: {
-    id: string;
-    display_name: string;
-    active: boolean;
-  };
-}
-
-interface FettMattisLeaderboardResponse {
-  rank?: number | null;
-  fettmattis_count: number;
-  player: {
-    id: string;
-    display_name: string;
-    active: boolean;
-  };
-}
 
 function createQuery(scope: LeaderboardScope) {
   const params = new URLSearchParams();
@@ -49,9 +31,14 @@ export async function getRegularLeaderboard(
     throw new Error("Failed to load regular leaderboard.");
   }
 
-  const data = (await response.json()) as RegularLeaderboardResponse[];
+  const payload = (await response.json()) as unknown;
+  const parsed = RegularLeaderboardResponseSchema.safeParse(payload);
 
-  return data.map((entry, index) => ({
+  if (!parsed.success) {
+    throw new Error("Received an invalid response when loading the leaderboard.");
+  }
+
+  return parsed.data.map((entry, index) => ({
     playerId: entry.player.id,
     playerName: entry.player.display_name,
     roundsPlayed: entry.participation_count,
@@ -77,9 +64,14 @@ export async function getFettmattisLeaderboard(
     throw new Error("Failed to load Fettmattis leaderboard.");
   }
 
-  const data = (await response.json()) as FettMattisLeaderboardResponse[];
+  const payload = (await response.json()) as unknown;
+  const parsed = FettmattisLeaderboardResponseSchema.safeParse(payload);
 
-  return data.map((entry, index) => ({
+  if (!parsed.success) {
+    throw new Error("Received an invalid response when loading the leaderboard.");
+  }
+
+  return parsed.data.map((entry, index) => ({
     playerId: entry.player.id,
     playerName: entry.player.display_name,
     fettmattisCount: entry.fettmattis_count,

--- a/tests/contract/post-fettmattis.test.ts
+++ b/tests/contract/post-fettmattis.test.ts
@@ -76,8 +76,14 @@ test("T013: POST /api/fettmattis returns 400 when validation fails", async () =>
   const response = await POST(request);
 
   expect(response.status).toBe(400);
+  const contentType = response.headers.get("Content-Type") ?? "";
+  expect(contentType).toContain("application/problem+json");
+
   const payload = await response.json();
-  expect(Array.isArray(payload.error)).toBe(true);
+  expect(() => ProblemDetailsSchema.parse(payload)).not.toThrow();
+  expect(payload.title).toBe("Bad Request");
+  expect(payload.detail).toBe("Must be a valid UUID.");
+  expect(mocks.createFettMattis).not.toHaveBeenCalled();
 });
 
 test("T013: POST /api/fettmattis returns 404 when the player or round is missing", async () => {

--- a/tests/contract/post-players.test.ts
+++ b/tests/contract/post-players.test.ts
@@ -57,8 +57,13 @@ test("T008: POST /api/players returns 400 when validation fails", async () => {
   const response = await POST(request);
 
   expect(response.status).toBe(400);
+  const contentType = response.headers.get("Content-Type") ?? "";
+  expect(contentType).toContain("application/problem+json");
+
   const payload = await response.json();
-  expect(Array.isArray(payload.error)).toBe(true);
+  expect(() => ProblemDetailsSchema.parse(payload)).not.toThrow();
+  expect(payload.title).toBe("Bad Request");
+  expect(payload.detail).toBe("Display name cannot be empty.");
   expect(mocks.createPlayer).not.toHaveBeenCalled();
 });
 

--- a/tests/contract/post-rounds.test.ts
+++ b/tests/contract/post-rounds.test.ts
@@ -111,8 +111,14 @@ test("T010: POST /api/rounds returns 400 when validation fails", async () => {
   const response = await POST(request);
 
   expect(response.status).toBe(400);
+  const contentType = response.headers.get("Content-Type") ?? "";
+  expect(contentType).toContain("application/problem+json");
+
   const payload = await response.json();
-  expect(Array.isArray(payload.error)).toBe(true);
+  expect(() => ProblemDetailsSchema.parse(payload)).not.toThrow();
+  expect(payload.title).toBe("Bad Request");
+  expect(payload.detail).toBe("A round must have at least two participants.");
+  expect(mocks.createRound).not.toHaveBeenCalled();
 });
 
 test("T010: POST /api/rounds returns 404 when a participant is missing", async () => {

--- a/tests/contract/put-player-by-id.test.ts
+++ b/tests/contract/put-player-by-id.test.ts
@@ -80,8 +80,12 @@ test("T020: PUT /api/players/{id} should return 400 on invalid body", async () =
   const res = await PUT(req, { params: Promise.resolve({ playerId }) });
 
   expect(res.status).toBe(400);
+  const contentType = res.headers.get("Content-Type") ?? "";
+  expect(contentType).toContain("application/problem+json");
+
   const body = await res.json();
-  expect(Array.isArray(body.error)).toBe(true);
-  expect(body.error[0]?.message).toBeDefined();
+  expect(() => ProblemDetailsSchema.parse(body)).not.toThrow();
+  expect(body.title).toBe("Bad Request");
+  expect(body.detail).toBe("Display name cannot be empty.");
   expect(mocks.updatePlayer).not.toHaveBeenCalled();
 });

--- a/tests/contract/put-round.test.ts
+++ b/tests/contract/put-round.test.ts
@@ -38,7 +38,10 @@ beforeEach(() => {
 });
 
 test("T011: PUT /api/rounds/{roundId} should return 400 if the request body is invalid", async () => {
-  const invalidBody = { participant_ids: ["p1"] }; // Invalid because less than 2 participants
+  const invalidBody = {
+    participant_ids: ["00000000-0000-7000-0000-000000000001"],
+    loser_id: "00000000-0000-7000-0000-000000000001",
+  }; // Invalid because less than 2 participants
 
   const req = createMockRequest(invalidBody);
   const res = await PUT(req, {
@@ -49,10 +52,12 @@ test("T011: PUT /api/rounds/{roundId} should return 400 if the request body is i
 
   expect(res.status).toBe(400);
   const contentType = res.headers.get("Content-Type") ?? "";
-  expect(contentType).toContain("application/json");
+  expect(contentType).toContain("application/problem+json");
 
   const body = await res.json();
-  expect(Array.isArray(body.error)).toBe(true);
+  expect(() => ProblemDetailsSchema.parse(body)).not.toThrow();
+  expect(body.title).toBe("Bad Request");
+  expect(body.detail).toBe("A round must have at least two participants.");
 
   // Ensure the database function was NOT called
   expect(mocks.updateRound).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add comprehensive Zod schemas mirroring the OpenAPI components and export shared types for reuse
- update API handlers and client utilities to validate requests/responses against the shared contracts and standardized problem details
- align the frontend (auth context, players and rounds flows, leaderboards) with the shared contracts for consistent runtime checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f2a6f630488333aa50763f6b2ffc9e