### PR TITLE
Refactor API clients with shared fetch helper and sync OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -262,8 +262,6 @@ paths:
                 $ref: "#/components/schemas/Round"
         "404":
           $ref: "#/components/responses/NotFound"
-        "410":
-          $ref: "#/components/responses/Gone"
     put:
       summary: Edit a Round (within 24h)
       operationId: updateRound
@@ -298,6 +296,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
     delete:
@@ -750,12 +750,6 @@ components:
             $ref: "#/components/schemas/Problem"
     Conflict:
       description: The resource already exists or the request conflicts with the current state.
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/Problem"
-    Gone:
-      description: The resource has been deleted.
       content:
         application/problem+json:
           schema:

--- a/src/lib/api/fetch-json.ts
+++ b/src/lib/api/fetch-json.ts
@@ -1,5 +1,4 @@
-import type { ZodTypeAny } from "zod";
-import type { z } from "zod";
+import type { ZodTypeAny, z } from "zod";
 
 interface FetchJsonOptions<TSchema extends ZodTypeAny> {
   input: RequestInfo | URL;

--- a/src/lib/api/fetch-json.ts
+++ b/src/lib/api/fetch-json.ts
@@ -1,0 +1,40 @@
+import type { ZodTypeAny } from "zod";
+import type { z } from "zod";
+
+interface FetchJsonOptions<TSchema extends ZodTypeAny> {
+  input: RequestInfo | URL;
+  init?: RequestInit;
+  schema: TSchema;
+  requestErrorMessage: string;
+  parseErrorMessage: string;
+}
+
+export async function fetchJson<TSchema extends ZodTypeAny>(
+  options: FetchJsonOptions<TSchema>,
+): Promise<z.infer<TSchema>> {
+  const response = await fetch(options.input, {
+    cache: "no-store",
+    ...options.init,
+  });
+
+  if (!response.ok) {
+    throw new Error(options.requestErrorMessage);
+  }
+
+  return parseJsonResponse(response, options.schema, options.parseErrorMessage);
+}
+
+export async function parseJsonResponse<TSchema extends ZodTypeAny>(
+  response: Response,
+  schema: TSchema,
+  parseErrorMessage: string,
+): Promise<z.infer<TSchema>> {
+  const payload = (await response.json()) as unknown;
+  const parsed = schema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new Error(parseErrorMessage);
+  }
+
+  return parsed.data;
+}

--- a/src/lib/api/players-client.ts
+++ b/src/lib/api/players-client.ts
@@ -1,5 +1,5 @@
 import type { QueryKey } from "@tanstack/react-query";
-
+import { fetchJson, parseJsonResponse } from "./fetch-json";
 import {
   type Player,
   PlayerSchema,
@@ -8,7 +8,6 @@ import {
   PlayerUpdateSchema,
   ProblemDetailsSchema,
 } from "./schemas";
-import { fetchJson, parseJsonResponse } from "./fetch-json";
 
 export const PLAYERS_QUERY_KEY = ["players"] as const satisfies QueryKey;
 

--- a/src/lib/api/players-client.ts
+++ b/src/lib/api/players-client.ts
@@ -8,28 +8,18 @@ import {
   PlayerUpdateSchema,
   ProblemDetailsSchema,
 } from "./schemas";
+import { fetchJson, parseJsonResponse } from "./fetch-json";
 
 export const PLAYERS_QUERY_KEY = ["players"] as const satisfies QueryKey;
 
 export async function fetchPlayers(): Promise<Player[]> {
-  const response = await fetch("/api/players", {
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(
+  return fetchJson({
+    input: "/api/players",
+    schema: PlayersResponseSchema,
+    requestErrorMessage:
       "We couldn't load the players right now. Please try again.",
-    );
-  }
-
-  const payload = (await response.json()) as unknown;
-  const parsed = PlayersResponseSchema.safeParse(payload);
-
-  if (!parsed.success) {
-    throw new Error("Received an invalid response when loading players.");
-  }
-
-  return parsed.data;
+    parseErrorMessage: "Received an invalid response when loading players.",
+  });
 }
 
 export const resolvePlayerError = (payload: unknown): string | undefined => {
@@ -69,12 +59,9 @@ export async function updatePlayer(
     throw new Error(detail ?? "We couldn't update the player right now.");
   }
 
-  const responseBody = (await response.json()) as unknown;
-  const parsed = PlayerSchema.safeParse(responseBody);
-
-  if (!parsed.success) {
-    throw new Error("Received an invalid response when updating the player.");
-  }
-
-  return parsed.data;
+  return parseJsonResponse(
+    response,
+    PlayerSchema,
+    "Received an invalid response when updating the player.",
+  );
 }

--- a/src/lib/api/rounds-client.ts
+++ b/src/lib/api/rounds-client.ts
@@ -1,5 +1,6 @@
 import type { QueryKey } from "@tanstack/react-query";
 
+import { fetchJson } from "@/lib/api/fetch-json";
 import { LatestRoundResponseSchema, type Round } from "@/lib/api/schemas";
 
 export const LATEST_ROUND_QUERY_KEY = [
@@ -8,24 +9,14 @@ export const LATEST_ROUND_QUERY_KEY = [
 ] as const satisfies QueryKey;
 
 export async function fetchLatestRound(): Promise<Round | null> {
-  const response = await fetch("/api/rounds/latest", {
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(
+  return fetchJson({
+    input: "/api/rounds/latest",
+    schema: LatestRoundResponseSchema,
+    requestErrorMessage:
       "We couldn't load the most recent round right now. Please try again.",
-    );
-  }
-
-  const payload = (await response.json()) as unknown;
-  const parsed = LatestRoundResponseSchema.safeParse(payload);
-
-  if (!parsed.success) {
-    throw new Error("Received an invalid response when loading latest round.");
-  }
-
-  return parsed.data;
+    parseErrorMessage:
+      "Received an invalid response when loading latest round.",
+  });
 }
 
 export type { Round } from "@/lib/api/schemas";


### PR DESCRIPTION
## Summary
- add a reusable JSON fetch helper to centralize schema validation for client calls
- update the players and rounds clients to rely on the shared helper and reduce duplication
- align the OpenAPI contract with the implemented round endpoints by removing 410 responses and documenting 409 conflicts

## Testing
- npm run tsc

------
https://chatgpt.com/codex/tasks/task_e_68f3ee347f648333a4825de943839cc8