### PR TITLE
feat: enhance mobile responsiveness across key pages

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,24 +1,23 @@
 import { Leaderboard } from "@/components/Leaderboard";
+import { PageShell } from "@/components/layout/page-shell";
+import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
 
 export default function LeaderboardPage() {
   return (
-    <div className="container space-y-8 pt-12 pb-16">
-      <div className="flex flex-col gap-2 text-left">
-        <Badge
-          variant="outline"
-          className="border-primary/40 text-primary w-fit"
-        >
-          Se tapsprosent
-        </Badge>
-        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-          Tabeller
-        </h1>
-        <p className="text-muted-foreground max-w-2xl text-sm">
-          Tallene oppdateres automatisk når en ny runde registreres.
-        </p>
-      </div>
+    <PageShell className="gap-10">
+      <SectionHeader
+        badge={
+          <Badge variant="outline" className="border-primary/40 text-primary">
+            Se tapsprosent
+          </Badge>
+        }
+        title="Tabeller"
+        description="Tallene oppdateres automatisk når en ny runde registreres."
+        titleAs="h1"
+        descriptionClassName="max-w-2xl"
+      />
       <Leaderboard />
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -47,7 +47,7 @@ export default function LoginPage() {
   const submitDisabled = loading || isSubmitting || email.length === 0 || password.length === 0;
 
   return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
+    <div className="container flex min-h-[60vh] items-center justify-center py-16">
       <div className="w-full max-w-md space-y-6 rounded-3xl border border-border/60 bg-background/60 p-8 shadow-lg backdrop-blur">
         <div className="space-y-2 text-center">
           <h1 className="text-2xl font-semibold">Logg inn</h1>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -168,8 +168,8 @@ export default async function Home() {
                 Klar for å registrere neste runde?
               </CardTitle>
               <CardDescription>
-                Gå direkte til rundeoversikten, eller finjuster spillerlisten før
-                neste kamp.
+                Gå direkte til rundeoversikten, eller finjuster spillerlisten
+                før neste kamp.
               </CardDescription>
             </CardHeader>
             <CardContent className="flex flex-col gap-3 p-6 pt-4 pb-6 sm:flex-row">
@@ -188,7 +188,10 @@ export default async function Home() {
         <div className="container flex flex-col items-center gap-6 text-center">
           <SectionHeader
             badge={
-              <Badge variant="outline" className="border-primary/40 text-primary">
+              <Badge
+                variant="outline"
+                className="border-primary/40 text-primary"
+              >
                 Skapt for nattlig skryt
               </Badge>
             }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { ArrowRight, CalendarRange, Trophy, Users2, Zap } from "lucide-react";
 import Link from "next/link";
 import { connection } from "next/server";
 import { Leaderboard } from "@/components/Leaderboard";
+import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -81,39 +82,37 @@ export default async function Home() {
     <div className="flex flex-col">
       <section className="border-border/60 bg-muted/40 border-b py-12">
         <div className="container space-y-8 pb-16">
-          <div className="flex flex-col gap-2 text-left">
-            <Badge
-              variant="outline"
-              className="border-primary/40 text-primary w-fit"
-            >
-              Se tapsprosent
-            </Badge>
-            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-              Hold oversikt over sesongen
-            </h1>
-            <p className="text-muted-foreground max-w-3xl text-sm">
-              Vanlig stilling og Fettmattis-utdelinger vises side om side og
-              oppdateres straks en runde registreres.
-            </p>
-          </div>
+          <SectionHeader
+            badge={
+              <Badge
+                variant="outline"
+                className="border-primary/40 text-primary"
+              >
+                Se tapsprosent
+              </Badge>
+            }
+            title="Hold oversikt over sesongen"
+            description="Vanlig stilling og Fettmattis-utdelinger vises side om side og oppdateres straks en runde registreres."
+            titleAs="h1"
+            descriptionClassName="max-w-3xl"
+          />
           <Leaderboard />
         </div>
       </section>
 
       <section className="relative overflow-hidden">
         <div className="relative container flex flex-col items-center gap-8 pt-24 pb-20 text-center md:pt-28">
-          <Badge className="bg-primary/10 text-primary shadow-primary/20 rounded-full shadow-xs">
-            Ny Mattis-opplevelse
-          </Badge>
-          <h2 className="text-foreground max-w-4xl text-2xl font-bold tracking-tight sm:text-5xl md:text-4xl">
-            Et vakkert hjem for hver Mattis-runde, hvert tap og hver
-            Fettmattis-feiring.
-          </h2>
-          <p className="text-muted-foreground max-w-2xl text-base sm:text-lg">
-            Registrer spillkveldene på sekunder, få oppdaterte tabeller og
-            gjenopplev Fettmattis-høydepunktene i et moderne grensesnitt laget
-            for Mattis-gjengen.
-          </p>
+          <SectionHeader
+            badge={
+              <Badge className="bg-primary/10 text-primary shadow-primary/20 rounded-full shadow-xs">
+                Ny Mattis-opplevelse
+              </Badge>
+            }
+            title="Et vakkert hjem for hver Mattis-runde, hvert tap og hver Fettmattis-feiring."
+            description="Registrer spillkveldene på sekunder, få oppdaterte tabeller og gjenopplev Fettmattis-høydepunktene i et moderne grensesnitt laget for Mattis-gjengen."
+            align="center"
+            descriptionClassName="max-w-2xl sm:text-lg"
+          />
           <div className="flex flex-col gap-3 sm:flex-row">
             <Button size="lg" asChild>
               <Link href="/leaderboard">
@@ -125,22 +124,9 @@ export default async function Home() {
               <Link href="/players">Administrer spillere</Link>
             </Button>
           </div>
-          <div className="border-border/50 bg-background/70 shadow-primary/10 mt-10 grid w-full gap-4 rounded-3xl border p-6 shadow-xl backdrop-blur-sm md:grid-cols-3">
+          <div className="mt-10 grid w-full gap-4 md:grid-cols-3">
             {highlightStats.map((stat) => (
-              <div
-                key={stat.label}
-                className="flex flex-col items-center gap-1"
-              >
-                <span className="text-3xl font-semibold tracking-tight md:text-4xl">
-                  {stat.value}
-                </span>
-                <span className="text-muted-foreground text-sm font-medium">
-                  {stat.label}
-                </span>
-                <p className="text-muted-foreground max-w-xs text-xs">
-                  {stat.description}
-                </p>
-              </div>
+              <StatHighlight key={stat.label} {...stat} />
             ))}
           </div>
         </div>
@@ -196,16 +182,17 @@ export default async function Home() {
 
       <section className="border-border/60 bg-muted/40 relative overflow-hidden border-t py-16">
         <div className="container flex flex-col items-center gap-6 text-center">
-          <Badge variant="outline" className="border-primary/40 text-primary">
-            Skapt for nattlig skryt
-          </Badge>
-          <h2 className="max-w-2xl text-3xl font-semibold tracking-tight sm:text-4xl">
-            Klar for mørk modus, mobilvennlig og laget for raske seiere.
-          </h2>
-          <p className="text-muted-foreground max-w-xl text-base">
-            Enten du logger siste runde for kvelden eller feirer en ny
-            Fettmattis, holder dette grensesnittet tempoet oppe.
-          </p>
+          <SectionHeader
+            badge={
+              <Badge variant="outline" className="border-primary/40 text-primary">
+                Skapt for nattlig skryt
+              </Badge>
+            }
+            title="Klar for mørk modus, mobilvennlig og laget for raske seiere."
+            description="Enten du logger siste runde for kvelden eller feirer en ny Fettmattis, holder dette grensesnittet tempoet oppe."
+            align="center"
+            descriptionClassName="max-w-xl"
+          />
           <div className="flex flex-col gap-3 sm:flex-row">
             <Button variant="secondary" asChild>
               <Link href="/players">Inviter gjengen</Link>
@@ -220,5 +207,29 @@ export default async function Home() {
         </div>
       </section>
     </div>
+  );
+}
+
+interface StatHighlightProps {
+  readonly label: string;
+  readonly value: string;
+  readonly description: string;
+}
+
+function StatHighlight({ label, value, description }: StatHighlightProps) {
+  return (
+    <Card className="border-border/60 bg-background/90 shadow-primary/10 flex h-full flex-col justify-between rounded-3xl border shadow-xl">
+      <CardHeader className="items-center gap-1 pb-2 text-center sm:pb-4">
+        <CardTitle className="text-3xl font-semibold tracking-tight md:text-4xl">
+          {value}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground text-sm font-medium">
+          {label}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="text-muted-foreground text-center text-xs sm:text-sm">
+        {description}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,8 +80,8 @@ export default async function Home() {
 
   return (
     <div className="flex flex-col">
-      <section className="border-border/60 bg-muted/40 border-b py-12">
-        <div className="container space-y-8 pb-16">
+      <section className="border-border/60 bg-muted/40 border-b py-16">
+        <div className="container flex flex-col gap-10">
           <SectionHeader
             badge={
               <Badge
@@ -100,8 +100,8 @@ export default async function Home() {
         </div>
       </section>
 
-      <section className="relative overflow-hidden">
-        <div className="relative container flex flex-col items-center gap-8 pt-24 pb-20 text-center md:pt-28">
+      <section className="relative overflow-hidden py-16 md:py-24">
+        <div className="relative container flex flex-col items-center gap-8 text-center">
           <SectionHeader
             badge={
               <Badge className="bg-primary/10 text-primary shadow-primary/20 rounded-full shadow-xs">
@@ -133,51 +133,55 @@ export default async function Home() {
         <div className="from-primary/15 absolute inset-x-0 top-1/2 -z-10 h-[480px] bg-linear-to-b via-transparent to-transparent blur-3xl" />
       </section>
 
-      <section className="container grid gap-6 pb-16 md:grid-cols-3">
-        {featureCards.map(({ Icon, title, description }) => (
-          <Card key={title} className="h-full">
-            <CardHeader className="pb-6">
-              <div className="bg-primary/10 text-primary flex h-12 w-12 items-center justify-center rounded-2xl">
-                <Icon className="h-6 w-6" />
-              </div>
-              <CardTitle>{title}</CardTitle>
-              <CardDescription>{description}</CardDescription>
-            </CardHeader>
-          </Card>
-        ))}
-      </section>
-
-      <section className="container grid gap-6 pb-16 lg:grid-cols-[1.1fr_0.9fr]">
-        <div className="grid gap-4">
-          {workflowCards.map((card) => (
-            <Card key={card.title} className="border-border/70 border-dashed">
+      <section className="py-16">
+        <div className="container grid gap-6 md:grid-cols-3">
+          {featureCards.map(({ Icon, title, description }) => (
+            <Card key={title} className="h-full">
               <CardHeader className="pb-6">
-                <CardTitle className="text-lg">{card.title}</CardTitle>
-                <CardDescription>{card.description}</CardDescription>
+                <div className="bg-primary/10 text-primary flex h-12 w-12 items-center justify-center rounded-2xl">
+                  <Icon className="h-6 w-6" />
+                </div>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
               </CardHeader>
             </Card>
           ))}
         </div>
-        <Card className="from-primary/10 via-background to-background bg-linear-to-br">
-          <CardHeader className="pb-4">
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <Zap className="text-primary h-5 w-5" />
-              Klar for å registrere neste runde?
-            </CardTitle>
-            <CardDescription>
-              Gå direkte til rundeoversikten, eller finjuster spillerlisten før
-              neste kamp.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-3 p-6 pt-4 pb-6 sm:flex-row">
-            <Button asChild className="flex-1">
-              <Link href="/rounds">Registrer en runde</Link>
-            </Button>
-            <Button variant="outline" asChild className="flex-1">
-              <Link href="/players">Administrer spillere</Link>
-            </Button>
-          </CardContent>
-        </Card>
+      </section>
+
+      <section className="py-16">
+        <div className="container grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="grid gap-4">
+            {workflowCards.map((card) => (
+              <Card key={card.title} className="border-border/70 border-dashed">
+                <CardHeader className="pb-6">
+                  <CardTitle className="text-lg">{card.title}</CardTitle>
+                  <CardDescription>{card.description}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+          <Card className="from-primary/10 via-background to-background bg-linear-to-br">
+            <CardHeader className="pb-4">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Zap className="text-primary h-5 w-5" />
+                Klar for å registrere neste runde?
+              </CardTitle>
+              <CardDescription>
+                Gå direkte til rundeoversikten, eller finjuster spillerlisten før
+                neste kamp.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3 p-6 pt-4 pb-6 sm:flex-row">
+              <Button asChild className="flex-1">
+                <Link href="/rounds">Registrer en runde</Link>
+              </Button>
+              <Button variant="outline" asChild className="flex-1">
+                <Link href="/players">Administrer spillere</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
       </section>
 
       <section className="border-border/60 bg-muted/40 relative overflow-hidden border-t py-16">

--- a/src/app/players/players-client.tsx
+++ b/src/app/players/players-client.tsx
@@ -5,6 +5,7 @@ import { RefreshCcw } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { PlayerForm } from "@/components/PlayerForm";
+import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -154,72 +155,74 @@ export default function PlayersClientPage() {
     );
   } else if (players.length > 0) {
     rosterContent = (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Spiller</TableHead>
-            <TableHead className="hidden sm:table-cell">Status</TableHead>
-            <TableHead className="hidden text-right sm:table-cell">
-              Handling
-            </TableHead>
-            <TableHead className="hidden text-right sm:table-cell">
-              ID
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {players.map((player) => (
-            <TableRow key={player.id}>
-              <TableCell>
-                <div className="flex flex-col">
-                  <span className="text-foreground font-medium">
-                    {player.display_name}
-                  </span>
-                  <span className="text-muted-foreground text-xs sm:hidden">
-                    {player.active ? "Aktiv" : "Inaktiv"}
-                  </span>
-                  <div className="mt-2 flex flex-wrap gap-2 sm:hidden">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        void handlePlayerUpdate(player, {
-                          active: !player.active,
-                        })
-                      }
-                      disabled={updatingPlayerId === player.id}
-                    >
-                      {player.active ? "Sett som inaktiv" : "Sett som aktiv"}
-                    </Button>
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell className="hidden sm:table-cell">
-                <Badge variant={player.active ? "success" : "outline"}>
-                  {player.active ? "Aktiv" : "Inaktiv"}
-                </Badge>
-              </TableCell>
-              <TableCell className="hidden text-right sm:table-cell">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    void handlePlayerUpdate(player, {
-                      active: !player.active,
-                    })
-                  }
-                  disabled={updatingPlayerId === player.id}
-                >
-                  {player.active ? "Sett som inaktiv" : "Sett som aktiv"}
-                </Button>
-              </TableCell>
-              <TableCell className="text-muted-foreground hidden text-right text-xs sm:table-cell">
-                {player.id.slice(0, 8)}…
-              </TableCell>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Spiller</TableHead>
+              <TableHead className="hidden sm:table-cell">Status</TableHead>
+              <TableHead className="hidden text-right sm:table-cell">
+                Handling
+              </TableHead>
+              <TableHead className="hidden text-right sm:table-cell">
+                ID
+              </TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {players.map((player) => (
+              <TableRow key={player.id}>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span className="text-foreground font-medium">
+                      {player.display_name}
+                    </span>
+                    <span className="text-muted-foreground text-xs sm:hidden">
+                      {player.active ? "Aktiv" : "Inaktiv"}
+                    </span>
+                    <div className="mt-2 flex flex-wrap gap-2 sm:hidden">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          void handlePlayerUpdate(player, {
+                            active: !player.active,
+                          })
+                        }
+                        disabled={updatingPlayerId === player.id}
+                      >
+                        {player.active ? "Sett som inaktiv" : "Sett som aktiv"}
+                      </Button>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="hidden sm:table-cell">
+                  <Badge variant={player.active ? "success" : "outline"}>
+                    {player.active ? "Aktiv" : "Inaktiv"}
+                  </Badge>
+                </TableCell>
+                <TableCell className="hidden text-right sm:table-cell">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      void handlePlayerUpdate(player, {
+                        active: !player.active,
+                      })
+                    }
+                    disabled={updatingPlayerId === player.id}
+                  >
+                    {player.active ? "Sett som inaktiv" : "Sett som aktiv"}
+                  </Button>
+                </TableCell>
+                <TableCell className="text-muted-foreground hidden text-right text-xs sm:table-cell">
+                  {player.id.slice(0, 8)}…
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     );
   } else {
     rosterContent = (
@@ -231,21 +234,17 @@ export default function PlayersClientPage() {
 
   return (
     <div className="container space-y-10 pt-12 pb-16">
-      <div className="flex flex-col gap-2 text-left">
-        <Badge
-          variant="outline"
-          className="border-primary/40 text-primary w-fit"
-        >
-          Verktøy for troppen
-        </Badge>
-        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-          Administrer Mattis-gjengen
-        </h1>
-        <p className="text-muted-foreground max-w-2xl text-sm">
-          Opprett nye spillere, behold inaktive legender i arkivet og hold
-          navnelisten ryddig til hver runde.
-        </p>
-      </div>
+      <SectionHeader
+        badge={
+          <Badge variant="outline" className="border-primary/40 text-primary">
+            Verktøy for troppen
+          </Badge>
+        }
+        title="Administrer Mattis-gjengen"
+        description="Opprett nye spillere, behold inaktive legender i arkivet og hold navnelisten ryddig til hver runde."
+        titleAs="h1"
+        descriptionClassName="max-w-2xl"
+      />
 
       <div className="grid gap-6 lg:grid-cols-[380px_1fr]">
         <Card>

--- a/src/app/players/players-client.tsx
+++ b/src/app/players/players-client.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { RefreshCcw } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { PageShell } from "@/components/layout/page-shell";
 import { PlayerForm } from "@/components/PlayerForm";
 import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
@@ -233,7 +234,7 @@ export default function PlayersClientPage() {
   }
 
   return (
-    <div className="container space-y-10 pt-12 pb-16">
+    <PageShell className="gap-10">
       <SectionHeader
         badge={
           <Badge variant="outline" className="border-primary/40 text-primary">
@@ -296,6 +297,6 @@ export default function PlayersClientPage() {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/rounds/rounds-client.tsx
+++ b/src/app/rounds/rounds-client.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarCheck, Trophy } from "lucide-react";
 import { useMemo, useState } from "react";
 import { FettMattisForm } from "@/components/FettMattisForm";
+import { PageShell } from "@/components/layout/page-shell";
 import { RoundForm } from "@/components/RoundForm";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -180,7 +181,7 @@ export default function RoundsClientPage() {
   };
 
   return (
-    <div className="container space-y-10 pt-12 pb-16">
+    <PageShell className="gap-10">
       <div className="flex flex-col gap-2 text-left">
         <Badge
           variant="outline"
@@ -284,6 +285,6 @@ export default function RoundsClientPage() {
           Oppdater spillerliste
         </Button>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/rounds/rounds-client.tsx
+++ b/src/app/rounds/rounds-client.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { FettMattisForm } from "@/components/FettMattisForm";
 import { PageShell } from "@/components/layout/page-shell";
 import { RoundForm } from "@/components/RoundForm";
+import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -73,7 +74,7 @@ export default function RoundsClientPage() {
 
   const activePlayers = useMemo(
     () => players.filter((player) => player.active),
-    [players],
+    [players]
   );
 
   const latestRoundParticipants = latestRoundQuery.data?.participants ?? [];
@@ -81,10 +82,10 @@ export default function RoundsClientPage() {
     () =>
       new Map(
         latestRoundParticipants.map(
-          (participant, index) => [participant.id, index] as const,
-        ),
+          (participant, index) => [participant.id, index] as const
+        )
       ),
-    [latestRoundParticipants],
+    [latestRoundParticipants]
   );
 
   const hydratablePlayers = useMemo(
@@ -113,7 +114,7 @@ export default function RoundsClientPage() {
 
           return a.displayName.localeCompare(b.displayName);
         }),
-    [activePlayers, participantOrder],
+    [activePlayers, participantOrder]
   );
 
   const roundMutation = useMutation<undefined, Error, RoundCreate>({
@@ -182,21 +183,18 @@ export default function RoundsClientPage() {
 
   return (
     <PageShell className="gap-10">
-      <div className="flex flex-col gap-2 text-left">
-        <Badge
-          variant="outline"
-          className="border-primary/40 text-primary w-fit"
-        >
-          Kontrollsenter for runder
-        </Badge>
-        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-          Loggfør runder og Fettmattis-øyeblikk
-        </h1>
-        <p className="text-muted-foreground max-w-2xl text-sm">
-          Registrer spillerne, lås taperen og feir Fettmattis-utdelinger – alt
-          fra ett sted.
-        </p>
-      </div>
+      <SectionHeader
+        badge={
+          <Badge
+            variant="outline"
+            className="border-primary/40 text-primary w-fit"
+          >
+            Kontrollsenter for runder
+          </Badge>
+        }
+        title="Loggfør runder og Fettmattis-øyeblikk"
+        description="Registrer spillerne, lås taperen og feir Fettmattis-utdelinger – alt fra ett sted."
+      />
 
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         <Card>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -4,7 +4,9 @@ import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, ChevronDown, Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useId, useMemo, useState } from "react";
+import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -13,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   getFettmattisLeaderboard,
   getRegularLeaderboard,
@@ -74,48 +77,50 @@ export function Leaderboard() {
     );
   } else {
     regularContent = (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-16">Plass</TableHead>
-            <TableHead>Spiller</TableHead>
-            <TableHead className="text-right">Tap %</TableHead>
-            <TableHead className="text-right">Tap</TableHead>
-            <TableHead className="text-right">Runder</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {regular.map((entry) => (
-            <TableRow key={entry.playerId}>
-              <TableCell className="font-semibold">#{entry.rank}</TableCell>
-              <TableCell className="flex items-center gap-3">
-                <div className="flex flex-col">
-                  <span className="text-foreground font-medium">
-                    {entry.playerName}
-                  </span>
-                  <span className="text-muted-foreground text-xs">
-                    {entry.roundsPlayed} runder spilt
-                  </span>
-                </div>
-                <Badge
-                  variant={entry.lossPercentage < 30 ? "success" : "outline"}
-                >
-                  {entry.lossPercentage.toFixed(1)}%
-                </Badge>
-              </TableCell>
-              <TableCell className="text-right font-semibold">
-                {entry.lossPercentage.toFixed(1)}%
-              </TableCell>
-              <TableCell className="text-muted-foreground text-right">
-                {entry.totalLosses}
-              </TableCell>
-              <TableCell className="text-muted-foreground text-right">
-                {entry.roundsPlayed}
-              </TableCell>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-16">Plass</TableHead>
+              <TableHead>Spiller</TableHead>
+              <TableHead className="text-right">Tap %</TableHead>
+              <TableHead className="text-right">Tap</TableHead>
+              <TableHead className="text-right">Runder</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {regular.map((entry) => (
+              <TableRow key={entry.playerId}>
+                <TableCell className="font-semibold">#{entry.rank}</TableCell>
+                <TableCell className="flex items-center gap-3">
+                  <div className="flex flex-col">
+                    <span className="text-foreground font-medium">
+                      {entry.playerName}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {entry.roundsPlayed} runder spilt
+                    </span>
+                  </div>
+                  <Badge
+                    variant={entry.lossPercentage < 30 ? "success" : "outline"}
+                  >
+                    {entry.lossPercentage.toFixed(1)}%
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right font-semibold">
+                  {entry.lossPercentage.toFixed(1)}%
+                </TableCell>
+                <TableCell className="text-muted-foreground text-right">
+                  {entry.totalLosses}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-right">
+                  {entry.roundsPlayed}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     );
   }
 
@@ -134,47 +139,46 @@ export function Leaderboard() {
     );
   } else {
     fettmattisContent = (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-16">Plass</TableHead>
-            <TableHead>Spiller</TableHead>
-            <TableHead className="text-right">FettMattis</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {fettmattis.map((entry) => (
-            <TableRow key={entry.playerId}>
-              <TableCell className="font-semibold">#{entry.rank}</TableCell>
-              <TableCell className="flex items-center gap-3">
-                <span className="text-foreground font-medium">
-                  {entry.playerName}
-                </span>
-                <Badge variant="secondary">Fettmattis-helt</Badge>
-              </TableCell>
-              <TableCell className="text-muted-foreground text-right">
-                {entry.fettmattisCount}
-              </TableCell>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-16">Plass</TableHead>
+              <TableHead>Spiller</TableHead>
+              <TableHead className="text-right">FettMattis</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {fettmattis.map((entry) => (
+              <TableRow key={entry.playerId}>
+                <TableCell className="font-semibold">#{entry.rank}</TableCell>
+                <TableCell className="flex items-center gap-3">
+                  <span className="text-foreground font-medium">
+                    {entry.playerName}
+                  </span>
+                  <Badge variant="secondary">Fettmattis-helt</Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground text-right">
+                  {entry.fettmattisCount}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     );
   }
 
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="flex flex-col items-start gap-2 text-left">
-          <h2 className="text-2xl font-semibold tracking-tight md:text-3xl">
-            Sesongoversikt for {isAllTime ? "alle år" : scope}
-          </h2>
-          <p className="text-muted-foreground max-w-2xl text-sm">
-            Tap-prosentene oppdateres med én gang en runde lagres.
-            Fettmattis-utdelinger følger 24-timersfristen for tilbakekalling.
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
+        <SectionHeader
+          title={`Sesongoversikt for ${isAllTime ? "alle år" : scope}`}
+          description="Tap-prosentene oppdateres med én gang en runde lagres. Fettmattis-utdelinger følger 24-timersfristen for tilbakekalling."
+          className="gap-2"
+          descriptionClassName="max-w-2xl"
+        />
+        <div className="flex items-center gap-3 self-start md:self-auto">
           <label
             className="text-muted-foreground text-sm font-medium"
             htmlFor={yearSelectId}
@@ -209,25 +213,36 @@ export function Leaderboard() {
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <section className="space-y-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <h3 className="text-lg font-semibold tracking-tight md:text-xl">
+      <div className="md:hidden">
+        <Tabs defaultValue="regular" className="w-full">
+          <TabsList className="w-full gap-2">
+            <TabsTrigger value="regular" className="flex-1">
               Vanlig tabell
-            </h3>
-            {regularLoading ? <LoadingNotice /> : null}
-          </div>
+            </TabsTrigger>
+            <TabsTrigger value="fettmattis" className="flex-1">
+              Fettmattis
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="regular" className="mt-6">
+            <LeaderboardPanel title="Vanlig tabell" loading={regularLoading}>
+              {regularContent}
+            </LeaderboardPanel>
+          </TabsContent>
+          <TabsContent value="fettmattis" className="mt-6">
+            <LeaderboardPanel title="Fettmattis-utdelinger" loading={fettmattisLoading}>
+              {fettmattisContent}
+            </LeaderboardPanel>
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <div className="hidden gap-6 md:grid lg:grid-cols-2">
+        <LeaderboardPanel title="Vanlig tabell" loading={regularLoading}>
           {regularContent}
-        </section>
-        <section className="space-y-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <h3 className="text-lg font-semibold tracking-tight md:text-xl">
-              Fettmattis-utdelinger
-            </h3>
-            {fettmattisLoading ? <LoadingNotice /> : null}
-          </div>
+        </LeaderboardPanel>
+        <LeaderboardPanel title="Fettmattis-utdelinger" loading={fettmattisLoading}>
           {fettmattisContent}
-        </section>
+        </LeaderboardPanel>
       </div>
     </div>
   );
@@ -266,5 +281,29 @@ function TableSkeleton() {
         />
       ))}
     </div>
+  );
+}
+
+interface LeaderboardPanelProps {
+  readonly title: string;
+  readonly loading: boolean;
+  readonly children: ReactNode;
+}
+
+function LeaderboardPanel({
+  title,
+  loading,
+  children,
+}: LeaderboardPanelProps) {
+  return (
+    <Card className="border-border/60 overflow-hidden rounded-3xl border">
+      <CardHeader className="flex flex-col gap-2 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <CardTitle className="text-lg font-semibold tracking-tight md:text-xl">
+          {title}
+        </CardTitle>
+        {loading ? <LoadingNotice /> : null}
+      </CardHeader>
+      <CardContent className="px-4 pb-6 sm:px-6">{children}</CardContent>
+    </Card>
   );
 }

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -28,8 +28,8 @@ import type {
 } from "@/lib/leaderboard-types";
 
 export function Leaderboard() {
-  const [scope, setScope] = useState<LeaderboardScope>(
-    () => new Date().getFullYear(),
+  const [scope, setScope] = useState<LeaderboardScope>(() =>
+    new Date().getFullYear()
   );
   const currentYear = useMemo(() => new Date().getFullYear(), []);
   const yearSelectId = useId();
@@ -63,9 +63,7 @@ export function Leaderboard() {
   const yearOptions = useMemo(() => {
     const seasons =
       availableSeasons.length > 0 ? availableSeasons : [currentYear];
-    const uniqueSeasons = Array.from(new Set(seasons)).sort(
-      (a, b) => b - a,
-    );
+    const uniqueSeasons = Array.from(new Set(seasons)).sort((a, b) => b - a);
 
     return [
       { value: "all" as const, label: "Alle år" },

--- a/src/components/layout/page-shell.tsx
+++ b/src/components/layout/page-shell.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PageShellProps {
+  readonly children: ReactNode;
+  readonly className?: string;
+}
+
+export function PageShell({ children, className }: PageShellProps) {
+  return (
+    <div
+      className={cn(
+        "container flex flex-col gap-12 py-16",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ElementType, ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -9,7 +9,7 @@ interface SectionHeaderProps {
   readonly align?: "left" | "center";
   readonly className?: string;
   readonly descriptionClassName?: string;
-  readonly titleAs?: keyof JSX.IntrinsicElements;
+  readonly titleAs?: ElementType;
 }
 
 export function SectionHeader({

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface SectionHeaderProps {
+  readonly badge?: ReactNode;
+  readonly title: ReactNode;
+  readonly description?: ReactNode;
+  readonly align?: "left" | "center";
+  readonly className?: string;
+  readonly descriptionClassName?: string;
+  readonly titleAs?: keyof JSX.IntrinsicElements;
+}
+
+export function SectionHeader({
+  badge,
+  title,
+  description,
+  align = "left",
+  className,
+  descriptionClassName,
+  titleAs = "h2",
+}: SectionHeaderProps) {
+  const HeadingTag = titleAs;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3",
+        align === "center" ? "items-center text-center" : "text-left",
+        className,
+      )}
+    >
+      {badge ? (
+        <div className={cn("w-fit", align === "center" ? "mx-auto" : undefined)}>
+          {badge}
+        </div>
+      ) : null}
+      <div className="space-y-2">
+        <HeadingTag className="text-3xl font-semibold tracking-tight sm:text-4xl">
+          {title}
+        </HeadingTag>
+        {description ? (
+          <p
+            className={cn(
+              "text-muted-foreground text-sm sm:text-base",
+              descriptionClassName,
+            )}
+          >
+            {description}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/tests/unit/__tests__/leaderboard-error-state.unit.test.tsx
+++ b/tests/unit/__tests__/leaderboard-error-state.unit.test.tsx
@@ -57,14 +57,14 @@ test("renders error panel for failed leaderboard queries", () => {
 
   render(<Leaderboard />);
 
-  const inlineError = screen.getByText(
+  const inlineErrors = screen.getAllByText(
     "Kunne ikke laste vanlige resultater. Prøv igjen senere.",
   );
   const bannerError = screen.getByText(
     "Kunne ikke hente vanlige resultater",
   );
 
-  expect(inlineError).toBeDefined();
+  expect(inlineErrors.length).toBeGreaterThan(0);
   expect(bannerError).toBeDefined();
   expect(
     screen.queryByText("Ingen runder registrert denne sesongen ennå."),


### PR DESCRIPTION
## Summary
- add a reusable SectionHeader component to keep hero and section intros consistent
- refresh the landing page with stat highlight cards and improved mobile spacing
- modernize the leaderboard view with card panels, mobile tabs, and responsive tables
- wrap the player roster table in a scroll container for small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3f3f0b4808333be72b45ecda4257e