### PR TITLE
Adjust leaderboard success badge threshold

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -98,7 +98,7 @@ export function Leaderboard() {
                   </span>
                 </div>
                 <Badge
-                  variant={entry.lossPercentage < 30 ? "success" : "outline"}
+                  variant={entry.lossPercentage < 20 ? "success" : "outline"}
                 >
                   {entry.lossPercentage.toFixed(1)}%
                 </Badge>


### PR DESCRIPTION
## Summary
- update the leaderboard success badge to apply to players below a 20% loss percentage so the highlight aligns with the intended threshold

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3fbf6d9448333972fbf996623beae