### PR TITLE
style: improve mobile leaderboard layout

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -94,39 +94,40 @@ export function Leaderboard() {
   } else {
     regularContent = (
       <div className="space-y-4">
-        <div className="md:hidden space-y-3">
+        <div className="md:hidden space-y-2.5">
           {regular.map((entry) => (
             <article
               key={entry.playerId}
-              className="border-border/60 bg-card text-card-foreground rounded-3xl border p-4 shadow-xs"
+              className="border-border/60 bg-card text-card-foreground rounded-2xl border p-3 shadow-xs"
             >
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-muted-foreground text-xs font-medium uppercase tracking-[0.2em]">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-muted-foreground text-[11px] font-medium uppercase tracking-[0.18em]">
                   #{entry.rank}
                 </span>
                 <Badge
                   variant={entry.lossPercentage < 30 ? "success" : "outline"}
+                  className="px-2 py-0.5 text-[11px] font-semibold"
                 >
                   {entry.lossPercentage.toFixed(1)}%
                 </Badge>
               </div>
-              <div className="mt-2">
-                <p className="text-lg font-semibold">{entry.playerName}</p>
+              <div className="mt-1.5">
+                <p className="text-base font-semibold">{entry.playerName}</p>
               </div>
-              <dl className="text-muted-foreground mt-4 grid grid-cols-2 gap-3 text-sm">
-                <div className="space-y-1">
-                  <dt className="text-xs font-medium uppercase tracking-[0.2em]">
+              <dl className="text-muted-foreground mt-3 grid grid-cols-2 gap-2 text-xs">
+                <div className="space-y-0.5">
+                  <dt className="text-[10px] font-medium uppercase tracking-[0.18em]">
                     Tap
                   </dt>
-                  <dd className="text-foreground text-base font-semibold">
+                  <dd className="text-foreground text-sm font-semibold">
                     {entry.totalLosses}
                   </dd>
                 </div>
-                <div className="space-y-1">
-                  <dt className="text-xs font-medium uppercase tracking-[0.2em]">
+                <div className="space-y-0.5">
+                  <dt className="text-[10px] font-medium uppercase tracking-[0.18em]">
                     Runder
                   </dt>
-                  <dd className="text-foreground text-base font-semibold">
+                  <dd className="text-foreground text-sm font-semibold">
                     {entry.roundsPlayed}
                   </dd>
                 </div>
@@ -192,23 +193,28 @@ export function Leaderboard() {
   } else {
     fettmattisContent = (
       <div className="space-y-4">
-        <div className="md:hidden space-y-3">
+        <div className="md:hidden space-y-2.5">
           {fettmattis.map((entry) => (
             <article
               key={entry.playerId}
-              className="border-border/60 bg-card text-card-foreground rounded-3xl border p-4 shadow-xs"
+              className="border-border/60 bg-card text-card-foreground rounded-2xl border p-3 shadow-xs"
             >
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-muted-foreground text-xs font-medium uppercase tracking-[0.2em]">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-muted-foreground text-[11px] font-medium uppercase tracking-[0.18em]">
                   #{entry.rank}
                 </span>
-                <Badge variant="secondary">Fettmattis-helt</Badge>
+                <Badge
+                  variant="secondary"
+                  className="px-2 py-0.5 text-[11px] font-semibold"
+                >
+                  Fettmattis-helt
+                </Badge>
               </div>
-              <div className="mt-2">
-                <p className="text-lg font-semibold">{entry.playerName}</p>
+              <div className="mt-1.5">
+                <p className="text-base font-semibold">{entry.playerName}</p>
               </div>
-              <div className="text-muted-foreground mt-4 text-sm">
-                <span className="text-foreground text-base font-semibold">
+              <div className="text-muted-foreground mt-3 text-xs">
+                <span className="text-foreground text-sm font-semibold">
                   {entry.fettmattisCount}
                 </span>{" "}
                 tildelinger

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -93,49 +93,81 @@ export function Leaderboard() {
     );
   } else {
     regularContent = (
-      <div className="overflow-x-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-16">Plass</TableHead>
-              <TableHead>Spiller</TableHead>
-              <TableHead className="text-right">Tap %</TableHead>
-              <TableHead className="text-right">Tap</TableHead>
-              <TableHead className="text-right">Runder</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {regular.map((entry) => (
-              <TableRow key={entry.playerId}>
-                <TableCell className="font-semibold">#{entry.rank}</TableCell>
-                <TableCell className="flex items-center gap-3">
-                  <div className="flex flex-col">
+      <div className="space-y-4">
+        <div className="md:hidden space-y-3">
+          {regular.map((entry) => (
+            <article
+              key={entry.playerId}
+              className="border-border/60 bg-card text-card-foreground rounded-3xl border p-4 shadow-xs"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground text-xs font-medium uppercase tracking-[0.2em]">
+                  #{entry.rank}
+                </span>
+                <Badge
+                  variant={entry.lossPercentage < 30 ? "success" : "outline"}
+                >
+                  {entry.lossPercentage.toFixed(1)}%
+                </Badge>
+              </div>
+              <div className="mt-2">
+                <p className="text-lg font-semibold">{entry.playerName}</p>
+              </div>
+              <dl className="text-muted-foreground mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div className="space-y-1">
+                  <dt className="text-xs font-medium uppercase tracking-[0.2em]">
+                    Tap
+                  </dt>
+                  <dd className="text-foreground text-base font-semibold">
+                    {entry.totalLosses}
+                  </dd>
+                </div>
+                <div className="space-y-1">
+                  <dt className="text-xs font-medium uppercase tracking-[0.2em]">
+                    Runder
+                  </dt>
+                  <dd className="text-foreground text-base font-semibold">
+                    {entry.roundsPlayed}
+                  </dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+        <div className="hidden overflow-x-auto md:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-16">Plass</TableHead>
+                <TableHead>Spiller</TableHead>
+                <TableHead className="text-right">Tap %</TableHead>
+                <TableHead className="text-right">Tap</TableHead>
+                <TableHead className="text-right">Runder</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {regular.map((entry) => (
+                <TableRow key={entry.playerId}>
+                  <TableCell className="font-semibold">#{entry.rank}</TableCell>
+                  <TableCell>
                     <span className="text-foreground font-medium">
                       {entry.playerName}
                     </span>
-                    <span className="text-muted-foreground text-xs">
-                      {entry.roundsPlayed} runder spilt
-                    </span>
-                  </div>
-                  <Badge
-                    variant={entry.lossPercentage < 30 ? "success" : "outline"}
-                  >
+                  </TableCell>
+                  <TableCell className="text-right font-semibold">
                     {entry.lossPercentage.toFixed(1)}%
-                  </Badge>
-                </TableCell>
-                <TableCell className="text-right font-semibold">
-                  {entry.lossPercentage.toFixed(1)}%
-                </TableCell>
-                <TableCell className="text-muted-foreground text-right">
-                  {entry.totalLosses}
-                </TableCell>
-                <TableCell className="text-muted-foreground text-right">
-                  {entry.roundsPlayed}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-right">
+                    {entry.totalLosses}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-right">
+                    {entry.roundsPlayed}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       </div>
     );
   }
@@ -159,32 +191,57 @@ export function Leaderboard() {
     );
   } else {
     fettmattisContent = (
-      <div className="overflow-x-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-16">Plass</TableHead>
-              <TableHead>Spiller</TableHead>
-              <TableHead className="text-right">FettMattis</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {fettmattis.map((entry) => (
-              <TableRow key={entry.playerId}>
-                <TableCell className="font-semibold">#{entry.rank}</TableCell>
-                <TableCell className="flex items-center gap-3">
-                  <span className="text-foreground font-medium">
-                    {entry.playerName}
-                  </span>
-                  <Badge variant="secondary">Fettmattis-helt</Badge>
-                </TableCell>
-                <TableCell className="text-muted-foreground text-right">
+      <div className="space-y-4">
+        <div className="md:hidden space-y-3">
+          {fettmattis.map((entry) => (
+            <article
+              key={entry.playerId}
+              className="border-border/60 bg-card text-card-foreground rounded-3xl border p-4 shadow-xs"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground text-xs font-medium uppercase tracking-[0.2em]">
+                  #{entry.rank}
+                </span>
+                <Badge variant="secondary">Fettmattis-helt</Badge>
+              </div>
+              <div className="mt-2">
+                <p className="text-lg font-semibold">{entry.playerName}</p>
+              </div>
+              <div className="text-muted-foreground mt-4 text-sm">
+                <span className="text-foreground text-base font-semibold">
                   {entry.fettmattisCount}
-                </TableCell>
+                </span>{" "}
+                tildelinger
+              </div>
+            </article>
+          ))}
+        </div>
+        <div className="hidden overflow-x-auto md:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-16">Plass</TableHead>
+                <TableHead>Spiller</TableHead>
+                <TableHead className="text-right">FettMattis</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHeader>
+            <TableBody>
+              {fettmattis.map((entry) => (
+                <TableRow key={entry.playerId}>
+                  <TableCell className="font-semibold">#{entry.rank}</TableCell>
+                  <TableCell>
+                    <span className="text-foreground font-medium">
+                      {entry.playerName}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-right">
+                    {entry.fettmattisCount}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       </div>
     );
   }

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -94,40 +94,42 @@ export function Leaderboard() {
   } else {
     regularContent = (
       <div className="space-y-4">
-        <div className="md:hidden space-y-2.5">
+        <div className="md:hidden space-y-1">
           {regular.map((entry) => (
             <article
               key={entry.playerId}
-              className="border-border/60 bg-card text-card-foreground rounded-2xl border p-3 shadow-xs"
+              className="border-border/60 bg-card text-card-foreground rounded-xl border px-3 py-2 shadow-xs"
             >
               <div className="flex items-center justify-between gap-2">
-                <span className="text-muted-foreground text-[11px] font-medium uppercase tracking-[0.18em]">
-                  #{entry.rank}
-                </span>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-[0.2em]">
+                    #{entry.rank}
+                  </span>
+                  <p className="text-foreground text-sm font-semibold leading-snug">
+                    {entry.playerName}
+                  </p>
+                </div>
                 <Badge
                   variant={entry.lossPercentage < 30 ? "success" : "outline"}
-                  className="px-2 py-0.5 text-[11px] font-semibold"
+                  className="min-w-[3.5rem] justify-center px-1.5 py-0 text-[10px] font-semibold"
                 >
                   {entry.lossPercentage.toFixed(1)}%
                 </Badge>
               </div>
-              <div className="mt-1.5">
-                <p className="text-base font-semibold">{entry.playerName}</p>
-              </div>
-              <dl className="text-muted-foreground mt-3 grid grid-cols-2 gap-2 text-xs">
-                <div className="space-y-0.5">
-                  <dt className="text-[10px] font-medium uppercase tracking-[0.18em]">
+              <dl className="text-muted-foreground mt-1.5 flex items-center gap-2.5 text-[10px] leading-tight">
+                <div className="flex items-center gap-1.5">
+                  <dt className="text-[9px] font-semibold uppercase tracking-[0.16em]">
                     Tap
                   </dt>
-                  <dd className="text-foreground text-sm font-semibold">
+                  <dd className="text-foreground text-[13px] font-semibold leading-none">
                     {entry.totalLosses}
                   </dd>
                 </div>
-                <div className="space-y-0.5">
-                  <dt className="text-[10px] font-medium uppercase tracking-[0.18em]">
+                <div className="flex items-center gap-1.5">
+                  <dt className="text-[9px] font-semibold uppercase tracking-[0.16em]">
                     Runder
                   </dt>
-                  <dd className="text-foreground text-sm font-semibold">
+                  <dd className="text-foreground text-[13px] font-semibold leading-none">
                     {entry.roundsPlayed}
                   </dd>
                 </div>
@@ -193,30 +195,32 @@ export function Leaderboard() {
   } else {
     fettmattisContent = (
       <div className="space-y-4">
-        <div className="md:hidden space-y-2.5">
+        <div className="md:hidden space-y-1">
           {fettmattis.map((entry) => (
             <article
               key={entry.playerId}
-              className="border-border/60 bg-card text-card-foreground rounded-2xl border p-3 shadow-xs"
+              className="border-border/60 bg-card text-card-foreground rounded-xl border px-3 py-2 shadow-xs"
             >
               <div className="flex items-center justify-between gap-2">
-                <span className="text-muted-foreground text-[11px] font-medium uppercase tracking-[0.18em]">
-                  #{entry.rank}
-                </span>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-[0.2em]">
+                    #{entry.rank}
+                  </span>
+                  <p className="text-foreground text-sm font-semibold leading-snug">
+                    {entry.playerName}
+                  </p>
+                </div>
                 <Badge
                   variant="secondary"
-                  className="px-2 py-0.5 text-[11px] font-semibold"
+                  className="min-w-[5.5rem] justify-center px-1.5 py-0 text-[10px] font-semibold"
                 >
                   Fettmattis-helt
                 </Badge>
               </div>
-              <div className="mt-1.5">
-                <p className="text-base font-semibold">{entry.playerName}</p>
-              </div>
-              <div className="text-muted-foreground mt-3 text-xs">
-                <span className="text-foreground text-sm font-semibold">
+              <div className="text-muted-foreground mt-1.5 flex items-center gap-1.5 text-[10px] leading-tight">
+                <span className="text-foreground text-[13px] font-semibold leading-none">
                   {entry.fettmattisCount}
-                </span>{" "}
+                </span>
                 tildelinger
               </div>
             </article>


### PR DESCRIPTION
## Summary
- add dedicated mobile card layouts for the leaderboard tables to improve readability
- remove duplicated round and loss percentage details from the desktop table cells

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f52b61a94c8333b74257a7fcf284f7