### PR TITLE
feat: add round and fettmattis activity tables

### DIFF
--- a/src/app/api/fettmattis/route.ts
+++ b/src/app/api/fettmattis/route.ts
@@ -1,14 +1,48 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
-import { toPlayerResponse } from "@/lib/api/response-helpers";
-import { FettMattisCreateSchema } from "@/lib/api/schemas";
+import { toFettMattisResponse } from "@/lib/api/response-helpers";
+import { FettMattisCreateSchema, ListQuerySchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
 import {
   ConflictError,
   createFettMattis,
+  listRecentFettMattis,
   NotFoundError,
 } from "@/lib/db-client";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = Object.fromEntries(searchParams.entries());
+
+  const validation = ListQuerySchema.safeParse(query);
+  if (!validation.success) {
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
+    return badRequest(detail);
+  }
+
+  try {
+    const fettMattisList = await listRecentFettMattis({
+      limit: validation.data.limit,
+    });
+    return NextResponse.json(fettMattisList.map(toFettMattisResponse));
+  } catch (error) {
+    if (error instanceof ConflictError) {
+      return createProblemResponse({
+        status: 409,
+        title: "Conflict",
+        detail: error.message,
+      });
+    }
+
+    return createProblemResponse({
+      status: 500,
+      title: "Internal Server Error",
+      detail: "Internal Server Error",
+    });
+  }
+}
 
 /**
  * POST /api/fettmattis
@@ -72,16 +106,4 @@ export async function POST(req: NextRequest) {
       detail: "Internal Server Error",
     });
   }
-}
-
-function toFettMattisResponse(record: {
-  id: string;
-  player: { id: string; displayName: string; active: boolean };
-  createdAt: Date;
-}) {
-  return {
-    id: record.id,
-    player: toPlayerResponse(record.player),
-    created_at: record.createdAt.toISOString(),
-  };
 }

--- a/src/app/api/rounds/route.ts
+++ b/src/app/api/rounds/route.ts
@@ -2,9 +2,45 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { toRoundResponse } from "@/lib/api/response-helpers";
-import { RoundCreateSchema } from "@/lib/api/schemas";
+import { ListQuerySchema, RoundCreateSchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
-import { ConflictError, createRound, NotFoundError } from "@/lib/db-client";
+import {
+  ConflictError,
+  createRound,
+  listRecentRounds,
+  NotFoundError,
+} from "@/lib/db-client";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = Object.fromEntries(searchParams.entries());
+
+  const validation = ListQuerySchema.safeParse(query);
+  if (!validation.success) {
+    const detail =
+      validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
+    return badRequest(detail);
+  }
+
+  try {
+    const rounds = await listRecentRounds({ limit: validation.data.limit });
+    return NextResponse.json(rounds.map(toRoundResponse));
+  } catch (error) {
+    if (error instanceof ConflictError) {
+      return createProblemResponse({
+        status: 409,
+        title: "Conflict",
+        detail: error.message,
+      });
+    }
+
+    return createProblemResponse({
+      status: 500,
+      title: "Internal Server Error",
+      detail: "Internal Server Error",
+    });
+  }
+}
 
 /**
  * POST /api/rounds

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
 import { ArrowRight, CalendarRange, Trophy, Users2, Zap } from "lucide-react";
 import Link from "next/link";
 import { connection } from "next/server";
+import { FettmattisTable } from "@/components/fettmattis-table";
 import { Leaderboard } from "@/components/Leaderboard";
+import { RoundsTable } from "@/components/rounds-table";
 import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,7 +14,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { getOverviewStats } from "@/lib/db-client";
+import { toFettMattisResponse, toRoundResponse } from "@/lib/api/response-helpers";
+import { getOverviewStats, listRecentFettMattis, listRecentRounds } from "@/lib/db-client";
 
 const featureCards = [
   {
@@ -56,8 +59,15 @@ const workflowCards = [
 export default async function Home() {
   await connection();
 
-  const { totalRounds, fettMattisMoments, activePlayers } =
-    await getOverviewStats();
+  const [overviewStats, recentRounds, recentFettMattis] = await Promise.all([
+    getOverviewStats(),
+    listRecentRounds({ limit: 5 }),
+    listRecentFettMattis({ limit: 5 }),
+  ]);
+
+  const { totalRounds, fettMattisMoments, activePlayers } = overviewStats;
+  const roundsForDisplay = recentRounds.map(toRoundResponse);
+  const fettMattisForDisplay = recentFettMattis.map(toFettMattisResponse);
   const formatter = new Intl.NumberFormat("nb-NO");
 
   const highlightStats = [
@@ -131,6 +141,47 @@ export default async function Home() {
           </div>
         </div>
         <div className="from-primary/15 absolute inset-x-0 top-1/2 -z-10 h-[480px] bg-linear-to-b via-transparent to-transparent blur-3xl" />
+      </section>
+
+      <section className="border-border/60 bg-muted/30 py-16">
+        <div className="container grid gap-6 lg:grid-cols-2">
+          <Card className="h-full">
+            <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <CardTitle>De siste rundene</CardTitle>
+                <CardDescription>
+                  Et lite utdrag av sesongens ferskeste registreringer.
+                </CardDescription>
+              </div>
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/rounds">Se alle runder</Link>
+              </Button>
+            </CardHeader>
+            <CardContent>
+              <RoundsTable
+                rounds={roundsForDisplay}
+                emptyMessage="Ingen runder er registrert ennå."
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="h-full">
+            <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <CardTitle>Ferske FettMattis</CardTitle>
+                <CardDescription>
+                  Hedringene som ble delt ut nylig.
+                </CardDescription>
+              </div>
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/rounds">Se tildelinger</Link>
+              </Button>
+            </CardHeader>
+            <CardContent>
+              <FettmattisTable fettMattis={fettMattisForDisplay} />
+            </CardContent>
+          </Card>
+        </div>
       </section>
 
       <section className="py-16">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,8 +14,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { toFettMattisResponse, toRoundResponse } from "@/lib/api/response-helpers";
-import { getOverviewStats, listRecentFettMattis, listRecentRounds } from "@/lib/db-client";
+import {
+  toFettMattisResponse,
+  toRoundResponse,
+} from "@/lib/api/response-helpers";
+import {
+  getOverviewStats,
+  listRecentFettMattis,
+  listRecentRounds,
+} from "@/lib/db-client";
 
 const featureCards = [
   {
@@ -131,7 +138,7 @@ export default async function Home() {
             <Card className="h-full">
               <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
                 <div className="space-y-1">
-                  <CardTitle>Ferske FettMattis</CardTitle>
+                  <CardTitle>Ferske Fettmattiser</CardTitle>
                   <CardDescription>
                     Hedringene som ble delt ut nylig.
                   </CardDescription>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -107,6 +107,44 @@ export default async function Home() {
             descriptionClassName="max-w-3xl"
           />
           <Leaderboard />
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card className="h-full">
+              <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-1">
+                  <CardTitle>De siste rundene</CardTitle>
+                  <CardDescription>
+                    Et lite utdrag av sesongens ferskeste registreringer.
+                  </CardDescription>
+                </div>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href="/rounds">Se alle runder</Link>
+                </Button>
+              </CardHeader>
+              <CardContent>
+                <RoundsTable
+                  rounds={roundsForDisplay}
+                  emptyMessage="Ingen runder er registrert ennå."
+                />
+              </CardContent>
+            </Card>
+
+            <Card className="h-full">
+              <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-1">
+                  <CardTitle>Ferske FettMattis</CardTitle>
+                  <CardDescription>
+                    Hedringene som ble delt ut nylig.
+                  </CardDescription>
+                </div>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href="/rounds">Se tildelinger</Link>
+                </Button>
+              </CardHeader>
+              <CardContent>
+                <FettmattisTable fettMattis={fettMattisForDisplay} />
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </section>
 
@@ -141,47 +179,6 @@ export default async function Home() {
           </div>
         </div>
         <div className="from-primary/15 absolute inset-x-0 top-1/2 -z-10 h-[480px] bg-linear-to-b via-transparent to-transparent blur-3xl" />
-      </section>
-
-      <section className="border-border/60 bg-muted/30 py-16">
-        <div className="container grid gap-6 lg:grid-cols-2">
-          <Card className="h-full">
-            <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-              <div className="space-y-1">
-                <CardTitle>De siste rundene</CardTitle>
-                <CardDescription>
-                  Et lite utdrag av sesongens ferskeste registreringer.
-                </CardDescription>
-              </div>
-              <Button variant="outline" size="sm" asChild>
-                <Link href="/rounds">Se alle runder</Link>
-              </Button>
-            </CardHeader>
-            <CardContent>
-              <RoundsTable
-                rounds={roundsForDisplay}
-                emptyMessage="Ingen runder er registrert ennå."
-              />
-            </CardContent>
-          </Card>
-
-          <Card className="h-full">
-            <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-              <div className="space-y-1">
-                <CardTitle>Ferske FettMattis</CardTitle>
-                <CardDescription>
-                  Hedringene som ble delt ut nylig.
-                </CardDescription>
-              </div>
-              <Button variant="outline" size="sm" asChild>
-                <Link href="/rounds">Se tildelinger</Link>
-              </Button>
-            </CardHeader>
-            <CardContent>
-              <FettmattisTable fettMattis={fettMattisForDisplay} />
-            </CardContent>
-          </Card>
-        </div>
       </section>
 
       <section className="py-16">

--- a/src/app/rounds/rounds-client.tsx
+++ b/src/app/rounds/rounds-client.tsx
@@ -22,6 +22,7 @@ import {
   createFettMattisListQueryKey,
   type FettMattis,
   fetchFettMattis,
+  revokeFettMattis,
 } from "@/lib/api/fettmattis-client";
 import {
   fetchPlayers,
@@ -30,6 +31,7 @@ import {
 } from "@/lib/api/players-client";
 import {
   createRoundsListQueryKey,
+  deleteRound,
   fetchLatestRound,
   fetchRounds,
   LATEST_ROUND_QUERY_KEY,
@@ -223,24 +225,8 @@ export default function RoundsClientPage() {
     await fettMattisMutation.mutateAsync(data);
   };
 
-  const deleteRoundMutation = useMutation<undefined, Error, string>({
-    mutationFn: async (roundId) => {
-      const response = await fetch(`/api/rounds/${roundId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!response.ok) {
-        let detail: string | undefined;
-        try {
-          const body: unknown = await response.json();
-          detail = resolveProblemDetail(body);
-        } catch {
-          detail = undefined;
-        }
-        throw new Error(detail ?? "Kunne ikke slette runden.");
-      }
-    },
+  const deleteRoundMutation = useMutation<void, Error, string>({
+    mutationFn: async (roundId) => deleteRound(roundId),
     onSuccess: () => {
       setStatus("Runde slettet. Tabellene er oppdatert!");
       setError(null);
@@ -256,25 +242,8 @@ export default function RoundsClientPage() {
     },
   });
 
-  const revokeFettMattisMutation = useMutation<undefined, Error, string>({
-    mutationFn: async (fettMattisId) => {
-      const response = await fetch(`/api/fettmattis/${fettMattisId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!response.ok) {
-        let detail: string | undefined;
-        try {
-          const body: unknown = await response.json();
-          detail = resolveProblemDetail(body);
-        } catch {
-          detail = undefined;
-        }
-
-        throw new Error(detail ?? "Kunne ikke slette Fettmattis.");
-      }
-    },
+  const revokeFettMattisMutation = useMutation<void, Error, string>({
+    mutationFn: async (fettMattisId) => revokeFettMattis(fettMattisId),
     onSuccess: () => {
       setStatus("Fettmattis fjernet. Oversikten er oppdatert.");
       setError(null);
@@ -431,7 +400,7 @@ export default function RoundsClientPage() {
         <Card>
           <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
             <div className="space-y-1">
-              <CardTitle>FettMattis-øyeblikk</CardTitle>
+              <CardTitle>Fettmattis-øyeblikk</CardTitle>
               <CardDescription>
                 Feiringene som fortsatt kan justeres det siste døgnet.
               </CardDescription>

--- a/src/app/rounds/rounds-client.tsx
+++ b/src/app/rounds/rounds-client.tsx
@@ -4,8 +4,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarCheck, Trophy } from "lucide-react";
 import { useMemo, useState } from "react";
 import { FettMattisForm } from "@/components/FettMattisForm";
+import { FettmattisTable } from "@/components/fettmattis-table";
 import { PageShell } from "@/components/layout/page-shell";
 import { RoundForm } from "@/components/RoundForm";
+import { RoundsTable } from "@/components/rounds-table";
 import { SectionHeader } from "@/components/section-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,12 +19,19 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
+  createFettMattisListQueryKey,
+  type FettMattis,
+  fetchFettMattis,
+} from "@/lib/api/fettmattis-client";
+import {
   fetchPlayers,
   PLAYERS_QUERY_KEY,
   type Player,
 } from "@/lib/api/players-client";
 import {
+  createRoundsListQueryKey,
   fetchLatestRound,
+  fetchRounds,
   LATEST_ROUND_QUERY_KEY,
   type Round,
 } from "@/lib/api/rounds-client";
@@ -53,6 +62,9 @@ const FETTMATTIS_FORM_SKELETON_KEYS = [
   "fettmattis-skeleton-3",
 ] as const;
 
+const ROUNDS_LIST_LIMIT = 25;
+const FETTMATTIS_LIST_LIMIT = 25;
+
 export default function RoundsClientPage() {
   const queryClient = useQueryClient();
   const [status, setStatus] = useState<string | null>(null);
@@ -71,6 +83,27 @@ export default function RoundsClientPage() {
     queryKey: LATEST_ROUND_QUERY_KEY,
     queryFn: fetchLatestRound,
   });
+
+  const roundsListQueryKey = createRoundsListQueryKey(ROUNDS_LIST_LIMIT);
+  const fettMattisListQueryKey =
+    createFettMattisListQueryKey(FETTMATTIS_LIST_LIMIT);
+
+  const roundsQuery = useQuery<Round[], Error>({
+    queryKey: roundsListQueryKey,
+    queryFn: () => fetchRounds({ limit: ROUNDS_LIST_LIMIT }),
+  });
+
+  const fettMattisQuery = useQuery<FettMattis[], Error>({
+    queryKey: fettMattisListQueryKey,
+    queryFn: () => fetchFettMattis({ limit: FETTMATTIS_LIST_LIMIT }),
+  });
+
+  const rounds = roundsQuery.data ?? [];
+  const fettMattisEntries = fettMattisQuery.data ?? [];
+  const isRoundsLoading = roundsQuery.isLoading;
+  const isRoundsFetching = roundsQuery.isFetching;
+  const isFettMattisLoading = fettMattisQuery.isLoading;
+  const isFettMattisFetching = fettMattisQuery.isFetching;
 
   const activePlayers = useMemo(
     () => players.filter((player) => player.active),
@@ -137,6 +170,12 @@ export default function RoundsClientPage() {
     onSuccess: () => {
       setStatus("Runde lagret. Tabellene er oppdatert!");
       setError(null);
+      void queryClient.invalidateQueries({
+        queryKey: roundsListQueryKey,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: LATEST_ROUND_QUERY_KEY,
+      });
       void queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
     },
     onError: (mutationError) => {
@@ -165,6 +204,9 @@ export default function RoundsClientPage() {
     onSuccess: () => {
       setStatus("Fettmattis tildelt. Klar for feiring!");
       setError(null);
+      void queryClient.invalidateQueries({
+        queryKey: fettMattisListQueryKey,
+      });
       void queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
     },
     onError: (mutationError) => {
@@ -180,6 +222,89 @@ export default function RoundsClientPage() {
   const handleFettMattisSubmit = async (data: FettMattisCreate) => {
     await fettMattisMutation.mutateAsync(data);
   };
+
+  const deleteRoundMutation = useMutation<undefined, Error, string>({
+    mutationFn: async (roundId) => {
+      const response = await fetch(`/api/rounds/${roundId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        let detail: string | undefined;
+        try {
+          const body: unknown = await response.json();
+          detail = resolveProblemDetail(body);
+        } catch {
+          detail = undefined;
+        }
+        throw new Error(detail ?? "Kunne ikke slette runden.");
+      }
+    },
+    onSuccess: () => {
+      setStatus("Runde slettet. Tabellene er oppdatert!");
+      setError(null);
+      void queryClient.invalidateQueries({ queryKey: roundsListQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: LATEST_ROUND_QUERY_KEY,
+      });
+      void queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
+    },
+    onError: (mutationError) => {
+      setStatus(null);
+      setError(mutationError.message);
+    },
+  });
+
+  const revokeFettMattisMutation = useMutation<undefined, Error, string>({
+    mutationFn: async (fettMattisId) => {
+      const response = await fetch(`/api/fettmattis/${fettMattisId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        let detail: string | undefined;
+        try {
+          const body: unknown = await response.json();
+          detail = resolveProblemDetail(body);
+        } catch {
+          detail = undefined;
+        }
+
+        throw new Error(detail ?? "Kunne ikke slette Fettmattis.");
+      }
+    },
+    onSuccess: () => {
+      setStatus("Fettmattis fjernet. Oversikten er oppdatert.");
+      setError(null);
+      void queryClient.invalidateQueries({ queryKey: fettMattisListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
+    },
+    onError: (mutationError) => {
+      setStatus(null);
+      setError(mutationError.message);
+    },
+  });
+
+  const handleRoundDelete = async (roundId: string) => {
+    await deleteRoundMutation.mutateAsync(roundId);
+  };
+
+  const handleFettMattisDelete = async (fettMattisId: string) => {
+    await revokeFettMattisMutation.mutateAsync(fettMattisId);
+  };
+
+  const deletingRoundIds =
+    deleteRoundMutation.isPending && deleteRoundMutation.variables
+      ? new Set([deleteRoundMutation.variables])
+      : undefined;
+
+  const deletingFettMattisIds =
+    revokeFettMattisMutation.isPending &&
+    revokeFettMattisMutation.variables
+      ? new Set([revokeFettMattisMutation.variables])
+      : undefined;
 
   return (
     <PageShell className="gap-10">
@@ -268,6 +393,73 @@ export default function RoundsClientPage() {
       {playersQuery.error ? (
         <p className="text-destructive text-sm">{playersQuery.error.message}</p>
       ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-1">
+              <CardTitle>Registrerte runder</CardTitle>
+              <CardDescription>
+                De siste registreringene fra Mattis-boka.
+              </CardDescription>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void roundsQuery.refetch()}
+              disabled={isRoundsFetching}
+            >
+              Oppdater
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <RoundsTable
+              rounds={rounds}
+              isLoading={isRoundsLoading}
+              onDeleteRound={handleRoundDelete}
+              deletingRoundIds={deletingRoundIds}
+              emptyMessage="Ingen runder er registrert ennå."
+            />
+            {roundsQuery.error ? (
+              <p className="text-destructive text-sm">
+                {roundsQuery.error.message}
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-1">
+              <CardTitle>FettMattis-øyeblikk</CardTitle>
+              <CardDescription>
+                Feiringene som fortsatt kan justeres det siste døgnet.
+              </CardDescription>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void fettMattisQuery.refetch()}
+              disabled={isFettMattisFetching}
+            >
+              Oppdater
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <FettmattisTable
+              fettMattis={fettMattisEntries}
+              isLoading={isFettMattisLoading}
+              onDelete={handleFettMattisDelete}
+              deletingIds={deletingFettMattisIds}
+            />
+            {fettMattisQuery.error ? (
+              <p className="text-destructive text-sm">
+                {fettMattisQuery.error.message}
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
 
       <div className="border-border/70 bg-muted/30 text-muted-foreground flex flex-wrap items-center gap-3 rounded-3xl border px-4 py-5 text-xs">
         <span>

--- a/src/components/fettmattis-table.tsx
+++ b/src/components/fettmattis-table.tsx
@@ -96,6 +96,11 @@ export function FettmattisTable({
               const deleting = deletingIds?.has(entry.id) ?? false;
               const canDelete = Boolean(onDelete) &&
                 Date.now() - createdAt.getTime() <= EDIT_WINDOW_MS;
+              const editWindowDeadline = new Date(
+                createdAt.getTime() + EDIT_WINDOW_MS,
+              );
+              const editWindowExpired = Date.now() >
+                editWindowDeadline.getTime();
 
               return (
                 <Fragment key={entry.id}>
@@ -159,12 +164,14 @@ export function FettmattisTable({
                             </div>
                             <div>
                               <p className="text-muted-foreground text-xs uppercase tracking-wide">
-                                Tilknyttet runde
+                                Endringsvindu
                               </p>
                               <p className="font-medium">
-                                {entry.round_id
-                                  ? `Runde ${entry.round_id.slice(0, 8)}…`
-                                  : "Ingen tilknyttet runde"}
+                                {editWindowExpired
+                                  ? "Låst for endringer"
+                                  : `Kan endres til ${DETAIL_DATETIME_FORMATTER.format(
+                                      editWindowDeadline,
+                                    )}`}
                               </p>
                             </div>
                           </div>

--- a/src/components/fettmattis-table.tsx
+++ b/src/components/fettmattis-table.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Fragment, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { FettMattis } from "@/lib/api/fettmattis-client";
+
+const DATETIME_FORMATTER = new Intl.DateTimeFormat("nb-NO", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const DETAIL_DATETIME_FORMATTER = new Intl.DateTimeFormat("nb-NO", {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const FETTMATTIS_TABLE_SKELETON_KEYS = [
+  "fettmattis-table-skeleton-1",
+  "fettmattis-table-skeleton-2",
+  "fettmattis-table-skeleton-3",
+] as const;
+
+interface FettmattisTableProps {
+  readonly fettMattis: FettMattis[];
+  readonly className?: string;
+  readonly isLoading?: boolean;
+  readonly onDelete?: (fettMattisId: string) => void | Promise<void>;
+  readonly deletingIds?: ReadonlySet<string>;
+  readonly emptyMessage?: string;
+}
+
+export function FettmattisTable({
+  fettMattis,
+  className,
+  isLoading = false,
+  onDelete,
+  deletingIds,
+  emptyMessage = "Ingen FettMattis-utdelinger registrert ennå.",
+}: FettmattisTableProps) {
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const toggle = (id: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const renderSkeletonRows = () => {
+    return FETTMATTIS_TABLE_SKELETON_KEYS.map((key) => (
+      <TableRow key={key}>
+        <TableCell colSpan={3}>
+          <div className="bg-muted/40 h-11 w-full animate-pulse rounded-2xl" />
+        </TableCell>
+      </TableRow>
+    ));
+  };
+
+  const hasEntries = fettMattis.length > 0;
+
+  return (
+    <Table className={className}>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Tildelt</TableHead>
+          <TableHead>Spiller</TableHead>
+          <TableHead className="text-right">Handling</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {isLoading ? renderSkeletonRows() : null}
+        {!isLoading && hasEntries
+          ? fettMattis.map((entry) => {
+              const createdAt = new Date(entry.created_at);
+              const formattedDate = DATETIME_FORMATTER.format(createdAt);
+              const detailDate = DETAIL_DATETIME_FORMATTER.format(createdAt);
+              const isExpanded = expanded.has(entry.id);
+              const deleting = deletingIds?.has(entry.id) ?? false;
+              const canDelete = Boolean(onDelete) &&
+                Date.now() - createdAt.getTime() <= EDIT_WINDOW_MS;
+
+              return (
+                <Fragment key={entry.id}>
+                  <TableRow>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium">{formattedDate}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {entry.player.display_name}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge className="w-fit">{entry.player.display_name}</Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => toggle(entry.id)}
+                          aria-expanded={isExpanded}
+                          aria-controls={`fettmattis-details-${entry.id}`}
+                        >
+                          {isExpanded ? "Skjul" : "Detaljer"}
+                        </Button>
+                        {onDelete && canDelete ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => onDelete(entry.id)}
+                            disabled={deleting}
+                          >
+                            {deleting ? "Sletter…" : "Slett"}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                  {isExpanded ? (
+                    <TableRow>
+                      <TableCell colSpan={3}>
+                        <div
+                          id={`fettmattis-details-${entry.id}`}
+                          className="bg-muted/30 border-border/60 text-sm rounded-3xl border px-4 py-4"
+                        >
+                          <div className="flex flex-col gap-3">
+                            <div>
+                              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                                Tildelt
+                              </p>
+                              <p className="font-medium">{detailDate}</p>
+                            </div>
+                            <div>
+                              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                                Spillerstatus
+                              </p>
+                              <p className="font-medium">
+                                {entry.player.active ? "Aktiv" : "Inaktiv"}
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                                Tilknyttet runde
+                              </p>
+                              <p className="font-medium">
+                                {entry.round_id
+                                  ? `Runde ${entry.round_id.slice(0, 8)}…`
+                                  : "Ingen tilknyttet runde"}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </Fragment>
+              );
+            })
+          : null}
+        {!isLoading && !hasEntries ? (
+          <TableRow>
+            <TableCell colSpan={3}>
+              <div className="text-muted-foreground flex justify-center py-6 text-sm">
+                {emptyMessage}
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : null}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/rounds-table.tsx
+++ b/src/components/rounds-table.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Fragment, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { Round } from "@/lib/api/schemas";
+import { cn } from "@/lib/utils";
+
+const DATETIME_FORMATTER = new Intl.DateTimeFormat("nb-NO", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const DETAIL_DATETIME_FORMATTER = new Intl.DateTimeFormat("nb-NO", {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const ROUND_TABLE_SKELETON_KEYS = [
+  "round-table-skeleton-1",
+  "round-table-skeleton-2",
+  "round-table-skeleton-3",
+  "round-table-skeleton-4",
+] as const;
+
+interface RoundsTableProps {
+  readonly rounds: Round[];
+  readonly className?: string;
+  readonly isLoading?: boolean;
+  readonly onDeleteRound?: (roundId: string) => void | Promise<void>;
+  readonly deletingRoundIds?: ReadonlySet<string>;
+  readonly emptyMessage?: string;
+}
+
+export function RoundsTable({
+  rounds,
+  className,
+  isLoading = false,
+  onDeleteRound,
+  deletingRoundIds,
+  emptyMessage = "Ingen runder registrert ennå.",
+}: RoundsTableProps) {
+  const [expandedRounds, setExpandedRounds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const toggleRound = (roundId: string) => {
+    setExpandedRounds((current) => {
+      const next = new Set(current);
+      if (next.has(roundId)) {
+        next.delete(roundId);
+      } else {
+        next.add(roundId);
+      }
+      return next;
+    });
+  };
+
+  const renderSkeletonRows = () => {
+    return ROUND_TABLE_SKELETON_KEYS.map((key) => (
+      <TableRow key={key}>
+        <TableCell colSpan={4}>
+          <div className="bg-muted/40 h-12 w-full animate-pulse rounded-2xl" />
+        </TableCell>
+      </TableRow>
+    ));
+  };
+
+  const hasRounds = rounds.length > 0;
+
+  return (
+    <Table className={className}>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Registrert</TableHead>
+          <TableHead>Mattis</TableHead>
+          <TableHead className="hidden text-right sm:table-cell">
+            Deltakere
+          </TableHead>
+          <TableHead className="text-right">Handling</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {isLoading ? renderSkeletonRows() : null}
+        {!isLoading && hasRounds
+          ? rounds.map((round) => {
+              const createdAt = new Date(round.created_at);
+              const formattedDate = DATETIME_FORMATTER.format(createdAt);
+              const detailDate = DETAIL_DATETIME_FORMATTER.format(createdAt);
+              const isExpanded = expandedRounds.has(round.id);
+              const participantCount = round.participants.length;
+              const deleting = deletingRoundIds?.has(round.id) ?? false;
+              const canDelete = Boolean(onDeleteRound) &&
+                Date.now() - createdAt.getTime() <= EDIT_WINDOW_MS;
+
+              return (
+                <Fragment key={round.id}>
+                  <TableRow>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium">{formattedDate}</span>
+                        <span className="text-muted-foreground text-xs sm:hidden">
+                          {participantCount} deltakere
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-medium">{round.loser.display_name}</span>
+                    </TableCell>
+                    <TableCell className="hidden text-right sm:table-cell">
+                      {participantCount}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => toggleRound(round.id)}
+                          aria-expanded={isExpanded}
+                          aria-controls={`round-details-${round.id}`}
+                        >
+                          {isExpanded ? "Skjul" : "Detaljer"}
+                        </Button>
+                        {onDeleteRound && canDelete ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => onDeleteRound(round.id)}
+                            disabled={deleting}
+                          >
+                            {deleting ? "Sletter…" : "Slett"}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                  {isExpanded ? (
+                    <TableRow>
+                      <TableCell colSpan={4}>
+                        <div
+                          id={`round-details-${round.id}`}
+                          className="bg-muted/30 border-border/60 text-sm rounded-3xl border px-4 py-4"
+                        >
+                          <div className="flex flex-col gap-3">
+                            <div>
+                              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                                Registrert
+                              </p>
+                              <p className="font-medium">{detailDate}</p>
+                            </div>
+                            <div>
+                              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                                Taper
+                              </p>
+                              <Badge variant="danger" className="w-fit">
+                                {round.loser.display_name}
+                              </Badge>
+                            </div>
+                            <div>
+                              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                                Deltakere
+                              </p>
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                {round.participants.map((participant) => {
+                                  const isLoser =
+                                    participant.id === round.loser.id;
+                                  return (
+                                    <Badge
+                                      key={participant.id}
+                                      variant={isLoser ? "danger" : "outline"}
+                                      className={cn(
+                                        "text-xs",
+                                        isLoser ? "font-semibold" : undefined,
+                                      )}
+                                    >
+                                      {participant.display_name}
+                                    </Badge>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </Fragment>
+              );
+            })
+          : null}
+        {!isLoading && !hasRounds ? (
+          <TableRow>
+            <TableCell colSpan={4}>
+              <div className="text-muted-foreground flex justify-center py-6 text-sm">
+                {emptyMessage}
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : null}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/lib/api/fetch-json.ts
+++ b/src/lib/api/fetch-json.ts
@@ -1,5 +1,7 @@
 import type { ZodTypeAny, z } from "zod";
 
+import { ProblemDetailsSchema } from "@/lib/api/schemas";
+
 interface FetchJsonOptions<TSchema extends ZodTypeAny> {
   input: RequestInfo | URL;
   init?: RequestInit;
@@ -21,6 +23,47 @@ export async function fetchJson<TSchema extends ZodTypeAny>(
   }
 
   return parseJsonResponse(response, options.schema, options.parseErrorMessage);
+}
+
+interface FetchWithProblemDetailsOptions {
+  input: RequestInfo | URL;
+  init?: RequestInit;
+  errorMessage: string;
+}
+
+export async function fetchWithProblemDetails({
+  input,
+  init,
+  errorMessage,
+}: FetchWithProblemDetailsOptions): Promise<Response> {
+  const response = await fetch(input, {
+    cache: "no-store",
+    ...init,
+  });
+
+  if (!response.ok) {
+    let detail: string | undefined;
+
+    const contentType = response.headers.get("content-type");
+    const hasJsonPayload =
+      typeof contentType === "string" && contentType.includes("json");
+
+    if (hasJsonPayload) {
+      try {
+        const payload = (await response.json()) as unknown;
+        const parsed = ProblemDetailsSchema.safeParse(payload);
+        if (parsed.success) {
+          detail = parsed.data.detail;
+        }
+      } catch {
+        detail = undefined;
+      }
+    }
+
+    throw new Error(detail ?? errorMessage);
+  }
+
+  return response;
 }
 
 export async function parseJsonResponse<TSchema extends ZodTypeAny>(

--- a/src/lib/api/fettmattis-client.ts
+++ b/src/lib/api/fettmattis-client.ts
@@ -1,0 +1,38 @@
+import type { QueryKey } from "@tanstack/react-query";
+
+import { fetchJson } from "@/lib/api/fetch-json";
+import {
+  type FettMattis,
+  FettMattisListResponseSchema,
+} from "@/lib/api/schemas";
+
+export function createFettMattisListQueryKey(limit?: number) {
+  return ["fettmattis", "list", limit ?? "default"] as const satisfies QueryKey;
+}
+
+interface FetchFettMattisOptions {
+  limit?: number;
+}
+
+export async function fetchFettMattis(
+  options: FetchFettMattisOptions = {},
+): Promise<FettMattis[]> {
+  const params = new URLSearchParams();
+  if (options.limit) {
+    params.set("limit", options.limit.toString());
+  }
+
+  const query = params.toString();
+  const url = query ? `/api/fettmattis?${query}` : "/api/fettmattis";
+
+  return fetchJson({
+    input: url,
+    schema: FettMattisListResponseSchema,
+    requestErrorMessage:
+      "Vi klarte ikke å laste FettMattis-oversikten nå. Prøv igjen litt senere.",
+    parseErrorMessage:
+      "Vi mottok et ugyldig svar da FettMattis-listen ble lastet.",
+  });
+}
+
+export type { FettMattis } from "@/lib/api/schemas";

--- a/src/lib/api/fettmattis-client.ts
+++ b/src/lib/api/fettmattis-client.ts
@@ -1,6 +1,6 @@
 import type { QueryKey } from "@tanstack/react-query";
 
-import { fetchJson } from "@/lib/api/fetch-json";
+import { fetchJson, fetchWithProblemDetails } from "@/lib/api/fetch-json";
 import {
   type FettMattis,
   FettMattisListResponseSchema,
@@ -36,3 +36,14 @@ export async function fetchFettMattis(
 }
 
 export type { FettMattis } from "@/lib/api/schemas";
+
+export async function revokeFettMattis(fettMattisId: string): Promise<void> {
+  await fetchWithProblemDetails({
+    input: `/api/fettmattis/${fettMattisId}`,
+    init: {
+      method: "DELETE",
+      credentials: "include",
+    },
+    errorMessage: "Kunne ikke slette Fettmattis.",
+  });
+}

--- a/src/lib/api/response-helpers.ts
+++ b/src/lib/api/response-helpers.ts
@@ -1,10 +1,11 @@
 import type {
+  FettMattisRecord,
   PlayerRecord,
   RoundParticipantRecord,
   RoundRecord,
 } from "@/lib/db-client";
 
-import type { Player, Round } from "./schemas";
+import type { FettMattis, Player, Round } from "./schemas";
 
 export type PlayerResponseInput =
   | Pick<PlayerRecord, "id" | "displayName" | "active">
@@ -13,6 +14,7 @@ export type PlayerResponseInput =
 export type PlayerResponse = Player;
 
 export type RoundResponse = Round;
+export type FettMattisResponse = FettMattis;
 
 export function toPlayerResponse(player: PlayerResponseInput): PlayerResponse {
   return {
@@ -28,5 +30,16 @@ export function toRoundResponse(round: RoundRecord): RoundResponse {
     created_at: round.createdAt.toISOString(),
     participants: round.participants.map(toPlayerResponse),
     loser: toPlayerResponse(round.loser),
+  };
+}
+
+export function toFettMattisResponse(
+  record: FettMattisRecord,
+): FettMattisResponse {
+  return {
+    id: record.id,
+    player: toPlayerResponse(record.player),
+    created_at: record.createdAt.toISOString(),
+    round_id: record.roundId ?? null,
   };
 }

--- a/src/lib/api/rounds-client.ts
+++ b/src/lib/api/rounds-client.ts
@@ -1,12 +1,45 @@
 import type { QueryKey } from "@tanstack/react-query";
 
 import { fetchJson } from "@/lib/api/fetch-json";
-import { LatestRoundResponseSchema, type Round } from "@/lib/api/schemas";
+import {
+  LatestRoundResponseSchema,
+  type Round,
+  RoundListResponseSchema,
+} from "@/lib/api/schemas";
 
 export const LATEST_ROUND_QUERY_KEY = [
   "rounds",
   "latest",
 ] as const satisfies QueryKey;
+
+export function createRoundsListQueryKey(limit?: number) {
+  return ["rounds", "list", limit ?? "default"] as const satisfies QueryKey;
+}
+
+interface FetchRoundsOptions {
+  limit?: number;
+}
+
+export async function fetchRounds(
+  options: FetchRoundsOptions = {},
+): Promise<Round[]> {
+  const params = new URLSearchParams();
+  if (options.limit) {
+    params.set("limit", options.limit.toString());
+  }
+
+  const query = params.toString();
+  const url = query ? `/api/rounds?${query}` : "/api/rounds";
+
+  return fetchJson({
+    input: url,
+    schema: RoundListResponseSchema,
+    requestErrorMessage:
+      "Vi klarte ikke å laste rundeoversikten nå. Prøv igjen litt senere.",
+    parseErrorMessage:
+      "Vi mottok et ugyldig svar da rundelisten ble lastet.",
+  });
+}
 
 export async function fetchLatestRound(): Promise<Round | null> {
   return fetchJson({

--- a/src/lib/api/rounds-client.ts
+++ b/src/lib/api/rounds-client.ts
@@ -1,6 +1,6 @@
 import type { QueryKey } from "@tanstack/react-query";
 
-import { fetchJson } from "@/lib/api/fetch-json";
+import { fetchJson, fetchWithProblemDetails } from "@/lib/api/fetch-json";
 import {
   LatestRoundResponseSchema,
   type Round,
@@ -49,6 +49,17 @@ export async function fetchLatestRound(): Promise<Round | null> {
       "We couldn't load the most recent round right now. Please try again.",
     parseErrorMessage:
       "Received an invalid response when loading latest round.",
+  });
+}
+
+export async function deleteRound(roundId: string): Promise<void> {
+  await fetchWithProblemDetails({
+    input: `/api/rounds/${roundId}`,
+    init: {
+      method: "DELETE",
+      credentials: "include",
+    },
+    errorMessage: "Kunne ikke slette runden.",
   });
 }
 

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -125,6 +125,10 @@ export const RoundUpdateSchema = z
 export const RoundListResponseSchema = RoundSchema.array();
 export const LatestRoundResponseSchema = RoundSchema.nullable();
 
+export const ListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
 // --- FettMattis Schemas ---
 
 export const FettMattisSchema = z.object({
@@ -212,6 +216,7 @@ export type RoundCreate = z.infer<typeof RoundCreateSchema>;
 export type RoundUpdate = z.infer<typeof RoundUpdateSchema>;
 export type FettMattis = z.infer<typeof FettMattisSchema>;
 export type FettMattisCreate = z.infer<typeof FettMattisCreateSchema>;
+export type ListQuery = z.infer<typeof ListQuerySchema>;
 export type RegularLeaderboardItem = z.infer<
   typeof RegularLeaderboardItemSchema
 >;

--- a/src/lib/db-client.ts
+++ b/src/lib/db-client.ts
@@ -46,6 +46,7 @@ export interface FettMattisRecord {
   createdAt: Date;
   createdBy: string;
   revokedAt: Date | null;
+  roundId: string | null;
 }
 
 export interface CreatePlayerInput {
@@ -410,6 +411,72 @@ export async function getMostRecentRound(): Promise<RoundRecord | null> {
   return round;
 }
 
+interface RecentListOptions {
+  limit?: number;
+}
+
+function resolveListLimit(limit: number | undefined): number {
+  if (!limit || Number.isNaN(limit)) {
+    return 20;
+  }
+
+  return Math.min(Math.max(Math.trunc(limit), 1), 100);
+}
+
+export async function listRecentRounds(
+  options: RecentListOptions = {},
+): Promise<RoundRecord[]> {
+  const listLimit = resolveListLimit(options.limit);
+
+  const roundRows = await db
+    .select({ id: rounds.id })
+    .from(rounds)
+    .where(isNull(rounds.deletedAt))
+    .orderBy(desc(rounds.createdAt))
+    .limit(listLimit);
+
+  const loadedRounds = await Promise.all(
+    roundRows.map(async ({ id }) => loadRound(db, id)),
+  );
+
+  return loadedRounds.filter((round): round is RoundRecord => round !== null);
+}
+
+export async function listRecentFettMattis(
+  options: RecentListOptions = {},
+): Promise<FettMattisRecord[]> {
+  const listLimit = resolveListLimit(options.limit);
+
+  const rows = await db
+    .select({
+      id: fettmattis.id,
+      playerId: fettmattis.playerId,
+      createdAt: fettmattis.createdAt,
+      createdBy: fettmattis.createdBy,
+      revokedAt: fettmattis.revokedAt,
+      playerDisplayName: players.displayName,
+      playerActive: players.active,
+    })
+    .from(fettmattis)
+    .innerJoin(players, eq(fettmattis.playerId, players.id))
+    .where(isNull(fettmattis.revokedAt))
+    .orderBy(desc(fettmattis.createdAt))
+    .limit(listLimit);
+
+  return rows.map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    createdBy: row.createdBy,
+    revokedAt: row.revokedAt,
+    roundId: null,
+    player: mapParticipant({
+      id: row.playerId,
+      displayName: row.playerDisplayName,
+      active: row.playerActive,
+    }),
+  }));
+}
+
 export async function updateRound(
   roundId: string,
   input: UpdateRoundInput,
@@ -532,6 +599,7 @@ export async function createFettMattis(
       createdAt: row.createdAt,
       createdBy: row.createdBy,
       revokedAt: row.revokedAt,
+      roundId: null,
     };
   });
 }

--- a/src/lib/db-client.ts
+++ b/src/lib/db-client.ts
@@ -46,7 +46,7 @@ export interface FettMattisRecord {
   createdAt: Date;
   createdBy: string;
   revokedAt: Date | null;
-  roundId: string | null;
+  roundId?: string | null;
 }
 
 export interface CreatePlayerInput {
@@ -463,18 +463,17 @@ export async function listRecentFettMattis(
     .orderBy(desc(fettmattis.createdAt))
     .limit(listLimit);
 
-  return rows.map((row) => ({
-    id: row.id,
-    createdAt: row.createdAt,
-    createdBy: row.createdBy,
-    revokedAt: row.revokedAt,
-    roundId: null,
-    player: mapParticipant({
-      id: row.playerId,
-      displayName: row.playerDisplayName,
-      active: row.playerActive,
-    }),
-  }));
+    return rows.map((row) => ({
+      id: row.id,
+      createdAt: row.createdAt,
+      createdBy: row.createdBy,
+      revokedAt: row.revokedAt,
+      player: mapParticipant({
+        id: row.playerId,
+        displayName: row.playerDisplayName,
+        active: row.playerActive,
+      }),
+    }));
 }
 
 export async function updateRound(
@@ -599,7 +598,6 @@ export async function createFettMattis(
       createdAt: row.createdAt,
       createdBy: row.createdBy,
       revokedAt: row.revokedAt,
-      roundId: null,
     };
   });
 }

--- a/tests/e2e/app-flows.spec.ts
+++ b/tests/e2e/app-flows.spec.ts
@@ -257,3 +257,203 @@ test("T037: leaderboard view surfaces regular and FettMattis standings", async (
     fettMattisTable.getByRole("row", { name: /Nova/ }),
   ).toBeVisible();
 });
+
+test("T193: rounds dashboard enforces 24-hour deletion window", async ({
+  page,
+}) => {
+  const now = Date.now();
+  const recentRound = {
+    id: "00000000-0000-7000-0000-000000000601",
+    created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+    participants: [
+      {
+        id: "00000000-0000-7000-0000-000000000611",
+        display_name: "Linus",
+        active: true,
+      },
+      {
+        id: "00000000-0000-7000-0000-000000000612",
+        display_name: "Maren",
+        active: true,
+      },
+    ],
+    loser: {
+      id: "00000000-0000-7000-0000-000000000611",
+      display_name: "Linus",
+      active: true,
+    },
+  } as const;
+  const archivedRound = {
+    id: "00000000-0000-7000-0000-000000000602",
+    created_at: new Date(now - 4 * 24 * 60 * 60 * 1000).toISOString(),
+    participants: [
+      {
+        id: "00000000-0000-7000-0000-000000000613",
+        display_name: "Morgan",
+        active: true,
+      },
+      {
+        id: "00000000-0000-7000-0000-000000000614",
+        display_name: "Iris",
+        active: true,
+      },
+    ],
+    loser: {
+      id: "00000000-0000-7000-0000-000000000613",
+      display_name: "Morgan",
+      active: true,
+    },
+  } as const;
+
+  const recentFettMattis = {
+    id: "00000000-0000-7000-0000-000000000701",
+    created_at: new Date(now - 60 * 60 * 1000).toISOString(),
+    player: {
+      id: "00000000-0000-7000-0000-000000000711",
+      display_name: "Ada",
+      active: true,
+    },
+    round_id: recentRound.id,
+  } as const;
+  const archivedFettMattis = {
+    id: "00000000-0000-7000-0000-000000000702",
+    created_at: new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    player: {
+      id: "00000000-0000-7000-0000-000000000712",
+      display_name: "Erik",
+      active: false,
+    },
+    round_id: null,
+  } as const;
+
+  const rounds = [structuredClone(recentRound), structuredClone(archivedRound)];
+  const fettMattisEntries = [
+    structuredClone(recentFettMattis),
+    structuredClone(archivedFettMattis),
+  ];
+
+  let roundDeleteCalled = false;
+  let fettMattisDeleteCalled = false;
+
+  await page.route(/\/api\/players$/, async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        { id: "00000000-0000-7000-0000-000000000611", display_name: "Linus", active: true },
+        { id: "00000000-0000-7000-0000-000000000612", display_name: "Maren", active: true },
+        { id: "00000000-0000-7000-0000-000000000613", display_name: "Morgan", active: true },
+        { id: "00000000-0000-7000-0000-000000000614", display_name: "Iris", active: true },
+        { id: "00000000-0000-7000-0000-000000000711", display_name: "Ada", active: true },
+        { id: "00000000-0000-7000-0000-000000000712", display_name: "Erik", active: false },
+      ]),
+    });
+  });
+
+  await page.route("**/api/rounds/latest", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(recentRound),
+    });
+  });
+
+  await page.route(/\/api\/rounds(\?.*)?$/, async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(rounds),
+    });
+  });
+
+  await page.route(
+    new RegExp(`/api/rounds/${recentRound.id.replaceAll("-", "\\-")}$`),
+    async (route, request) => {
+      expect(request.method()).toBe("DELETE");
+      roundDeleteCalled = true;
+      const index = rounds.findIndex((round) => round.id === recentRound.id);
+      if (index >= 0) {
+        rounds.splice(index, 1);
+      }
+
+      await route.fulfill({ status: 204, body: "" });
+    },
+  );
+
+  await page.route(/\/api\/fettmattis(\?.*)?$/, async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(fettMattisEntries),
+    });
+  });
+
+  await page.route(
+    new RegExp(`/api/fettmattis/${recentFettMattis.id.replaceAll("-", "\\-")}$`),
+    async (route, request) => {
+      expect(request.method()).toBe("DELETE");
+      fettMattisDeleteCalled = true;
+      const index = fettMattisEntries.findIndex(
+        (entry) => entry.id === recentFettMattis.id,
+      );
+      if (index >= 0) {
+        fettMattisEntries.splice(index, 1);
+      }
+
+      await route.fulfill({ status: 204, body: "" });
+    },
+  );
+
+  await page.goto("/rounds", { waitUntil: "networkidle" });
+
+  const recentRoundRow = page.getByRole("row", { name: /Linus/ });
+  await expect(recentRoundRow).toBeVisible();
+  await expect(recentRoundRow.getByRole("button", { name: "Slett" })).toBeVisible();
+
+  await recentRoundRow.getByRole("button", { name: "Detaljer" }).click();
+  await expect(page.getByText("Taper", { exact: false })).toBeVisible();
+
+  const archivedRoundRow = page.getByRole("row", { name: /Morgan/ });
+  await expect(archivedRoundRow.getByRole("button", { name: "Slett" })).toHaveCount(0);
+
+  await recentRoundRow.getByRole("button", { name: "Slett" }).click();
+  await expect(
+    page.getByText("Runde slettet. Tabellene er oppdatert!"),
+  ).toBeVisible();
+  await expect(page.getByRole("row", { name: /Linus/ })).toHaveCount(0);
+
+  expect(roundDeleteCalled).toBe(true);
+
+  const recentFettMattisRow = page.getByRole("row", { name: /Ada/ });
+  await expect(recentFettMattisRow.getByRole("button", { name: "Slett" })).toBeVisible();
+  await recentFettMattisRow.getByRole("button", { name: "Detaljer" }).click();
+  await expect(page.getByText("Spillerstatus")).toBeVisible();
+
+  const archivedFettMattisRow = page.getByRole("row", { name: /Erik/ });
+  await expect(
+    archivedFettMattisRow.getByRole("button", { name: "Slett" }),
+  ).toHaveCount(0);
+
+  await recentFettMattisRow.getByRole("button", { name: "Slett" }).click();
+  await expect(
+    page.getByText("Fettmattis fjernet. Oversikten er oppdatert."),
+  ).toBeVisible();
+  await expect(page.getByRole("row", { name: /Ada/ })).toHaveCount(0);
+
+  expect(fettMattisDeleteCalled).toBe(true);
+});

--- a/tests/e2e/app-flows.spec.ts
+++ b/tests/e2e/app-flows.spec.ts
@@ -313,7 +313,6 @@ test("T193: rounds dashboard enforces 24-hour deletion window", async ({
       display_name: "Ada",
       active: true,
     },
-    round_id: recentRound.id,
   } as const;
   const archivedFettMattis = {
     id: "00000000-0000-7000-0000-000000000702",
@@ -323,7 +322,6 @@ test("T193: rounds dashboard enforces 24-hour deletion window", async ({
       display_name: "Erik",
       active: false,
     },
-    round_id: null,
   } as const;
 
   const rounds = [structuredClone(recentRound), structuredClone(archivedRound)];
@@ -443,6 +441,7 @@ test("T193: rounds dashboard enforces 24-hour deletion window", async ({
   await expect(recentFettMattisRow.getByRole("button", { name: "Slett" })).toBeVisible();
   await recentFettMattisRow.getByRole("button", { name: "Detaljer" }).click();
   await expect(page.getByText("Spillerstatus")).toBeVisible();
+  await expect(page.getByText("Endringsvindu")).toBeVisible();
 
   const archivedFettMattisRow = page.getByRole("row", { name: /Erik/ });
   await expect(

--- a/tests/e2e/app-flows.spec.ts
+++ b/tests/e2e/app-flows.spec.ts
@@ -424,7 +424,9 @@ test("T193: rounds dashboard enforces 24-hour deletion window", async ({
   await expect(recentRoundRow.getByRole("button", { name: "Slett" })).toBeVisible();
 
   await recentRoundRow.getByRole("button", { name: "Detaljer" }).click();
-  await expect(page.getByText("Taper", { exact: false })).toBeVisible();
+  const roundDetails = page.locator(`#round-details-${recentRound.id}`);
+  await expect(roundDetails).toBeVisible();
+  await expect(roundDetails.getByText("Taper", { exact: false })).toBeVisible();
 
   const archivedRoundRow = page.getByRole("row", { name: /Morgan/ });
   await expect(archivedRoundRow.getByRole("button", { name: "Slett" })).toHaveCount(0);

--- a/tests/e2e/landing-page.spec.ts
+++ b/tests/e2e/landing-page.spec.ts
@@ -23,4 +23,34 @@ test.describe("Landing Page", () => {
       await expect(nav.getByRole("link", { name: "Runder" })).toBeVisible();
     });
   });
+
+  test("T193: recent activity tables appear below the leaderboard", async ({
+    page,
+  }) => {
+    const leaderboardHeading = page
+      .getByRole("heading", { name: "Vanlig tabell", level: 3 })
+      .first();
+    const roundsHeading = page.getByRole("heading", {
+      name: "De siste rundene",
+      level: 3,
+    });
+    const fettMattisHeading = page.getByRole("heading", {
+      name: "Ferske FettMattis",
+      level: 3,
+    });
+
+    await expect(roundsHeading).toBeVisible();
+    await expect(fettMattisHeading).toBeVisible();
+
+    const leaderboardBox = await leaderboardHeading.boundingBox();
+    const roundsBox = await roundsHeading.boundingBox();
+    const fettMattisBox = await fettMattisHeading.boundingBox();
+
+    if (!leaderboardBox || !roundsBox || !fettMattisBox) {
+      throw new Error("Unable to determine layout for leaderboard or activity tables.");
+    }
+
+    expect(roundsBox.y).toBeGreaterThan(leaderboardBox.y);
+    expect(fettMattisBox.y).toBeGreaterThan(leaderboardBox.y);
+  });
 });

--- a/tests/e2e/landing-page.spec.ts
+++ b/tests/e2e/landing-page.spec.ts
@@ -11,7 +11,7 @@ test.describe("Landing Page", () => {
         page.getByRole("heading", {
           name: "Et vakkert hjem for hver Mattis-runde, hvert tap og hver Fettmattis-feiring.",
           level: 2,
-        }),
+        })
       ).toBeVisible();
     });
 
@@ -35,7 +35,7 @@ test.describe("Landing Page", () => {
       level: 3,
     });
     const fettMattisHeading = page.getByRole("heading", {
-      name: "Ferske FettMattis",
+      name: "Ferske Fettmattiser",
       level: 3,
     });
 
@@ -47,7 +47,9 @@ test.describe("Landing Page", () => {
     const fettMattisBox = await fettMattisHeading.boundingBox();
 
     if (!leaderboardBox || !roundsBox || !fettMattisBox) {
-      throw new Error("Unable to determine layout for leaderboard or activity tables.");
+      throw new Error(
+        "Unable to determine layout for leaderboard or activity tables."
+      );
     }
 
     expect(roundsBox.y).toBeGreaterThan(leaderboardBox.y);

--- a/tests/unit/__tests__/activity-tables.unit.test.tsx
+++ b/tests/unit/__tests__/activity-tables.unit.test.tsx
@@ -19,7 +19,12 @@ const DEFAULT_PARTICIPANTS: Round["participants"] = [
 
 function createRound(overrides: Partial<Round> = {}): Round {
   const participants = overrides.participants ?? DEFAULT_PARTICIPANTS;
-  const loser = overrides.loser ?? participants[0] ?? DEFAULT_PARTICIPANTS[0]!;
+  const fallbackLoser = participants[0] ?? DEFAULT_PARTICIPANTS[0];
+  if (!fallbackLoser) {
+    throw new Error("Unable to create round without participants.");
+  }
+
+  const loser = overrides.loser ?? fallbackLoser;
 
   return {
     id: "round-1",
@@ -39,7 +44,6 @@ function createFettMattis(overrides: Partial<FettMattis> = {}): FettMattis {
     id: "fettmattis-1",
     created_at: new Date().toISOString(),
     player,
-    round_id: "round-1",
     ...overrides,
   } satisfies FettMattis;
 }
@@ -112,7 +116,6 @@ describe("Activity tables", () => {
   test("T193: FettMattis table exposes entry metadata when expanded", async () => {
     const entry = createFettMattis({
       created_at: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
-      round_id: "round-42",
     });
 
     render(<FettmattisTable fettMattis={[entry]} />);
@@ -128,7 +131,7 @@ describe("Activity tables", () => {
     );
     expect(detailSection).toBeTruthy();
     expect(detailSection?.textContent).toContain("Aktiv");
-    expect(detailSection?.textContent).toContain("round-42");
+    expect(detailSection?.textContent).toContain("Endringsvindu");
   });
 
   test("T193: FettMattis table restricts deletion after 24 hours", () => {

--- a/tests/unit/__tests__/activity-tables.unit.test.tsx
+++ b/tests/unit/__tests__/activity-tables.unit.test.tsx
@@ -1,0 +1,171 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { FettmattisTable } from "@/components/fettmattis-table";
+import { RoundsTable } from "@/components/rounds-table";
+import type { FettMattis } from "@/lib/api/fettmattis-client";
+import type { Round } from "@/lib/api/schemas";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+afterEach(() => {
+  cleanup();
+});
+
+const DEFAULT_PARTICIPANTS: Round["participants"] = [
+  { id: "player-1", display_name: "Nora", active: true },
+  { id: "player-2", display_name: "Iben", active: true },
+];
+
+function createRound(overrides: Partial<Round> = {}): Round {
+  const participants = overrides.participants ?? DEFAULT_PARTICIPANTS;
+  const loser = overrides.loser ?? participants[0] ?? DEFAULT_PARTICIPANTS[0]!;
+
+  return {
+    id: "round-1",
+    created_at: new Date().toISOString(),
+    participants,
+    loser,
+    ...overrides,
+  } satisfies Round;
+}
+
+function createFettMattis(overrides: Partial<FettMattis> = {}): FettMattis {
+  const player =
+    overrides.player ??
+    ({ id: "fett-1", display_name: "Ada", active: true } as FettMattis["player"]);
+
+  return {
+    id: "fettmattis-1",
+    created_at: new Date().toISOString(),
+    player,
+    round_id: "round-1",
+    ...overrides,
+  } satisfies FettMattis;
+}
+
+describe("Activity tables", () => {
+  test("T193: rounds table toggles expanded details", async () => {
+    const round = createRound({
+      created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      loser: { id: "player-2", display_name: "Iben", active: true },
+    });
+
+    render(
+      <RoundsTable
+        rounds={[round]}
+        emptyMessage="Ingen runder er registrert ennå."
+      />,
+    );
+
+    expect(screen.queryByText("Taper")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Detaljer" }));
+
+    const detailHeading = await screen.findByText("Taper");
+    expect(detailHeading).toBeTruthy();
+    const detailSection = document.getElementById(
+      `round-details-${round.id}`,
+    );
+    expect(detailSection).toBeTruthy();
+    expect(detailSection?.textContent).toContain("Iben");
+  });
+
+  test("T193: rounds table enables deletion within 24 hours", async () => {
+    const recentRound = createRound({
+      id: "recent-round",
+      created_at: new Date().toISOString(),
+    });
+    const onDelete = vi.fn();
+
+    render(
+      <RoundsTable
+        rounds={[recentRound]}
+        onDeleteRound={onDelete}
+        emptyMessage="Ingen runder er registrert ennå."
+      />,
+    );
+
+    const deleteButton = await screen.findByRole("button", { name: "Slett" });
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith("recent-round");
+  });
+
+  test("T193: rounds table hides deletion outside edit window", () => {
+    const oldRound = createRound({
+      created_at: new Date(Date.now() - DAY_IN_MS * 2).toISOString(),
+    });
+
+    render(
+      <RoundsTable
+        rounds={[oldRound]}
+        onDeleteRound={vi.fn()}
+        emptyMessage="Ingen runder er registrert ennå."
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Slett" })).toBeNull();
+  });
+
+  test("T193: FettMattis table exposes entry metadata when expanded", async () => {
+    const entry = createFettMattis({
+      created_at: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+      round_id: "round-42",
+    });
+
+    render(<FettmattisTable fettMattis={[entry]} />);
+
+    expect(screen.queryByText("Spillerstatus")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Detaljer" }));
+
+    const statusHeading = await screen.findByText("Spillerstatus");
+    expect(statusHeading).toBeTruthy();
+    const detailSection = document.getElementById(
+      `fettmattis-details-${entry.id}`,
+    );
+    expect(detailSection).toBeTruthy();
+    expect(detailSection?.textContent).toContain("Aktiv");
+    expect(detailSection?.textContent).toContain("round-42");
+  });
+
+  test("T193: FettMattis table restricts deletion after 24 hours", () => {
+    const staleEntry = createFettMattis({
+      created_at: new Date(Date.now() - DAY_IN_MS * 3).toISOString(),
+    });
+
+    render(
+      <FettmattisTable
+        fettMattis={[staleEntry]}
+        onDelete={vi.fn()}
+        emptyMessage="Ingen FettMattis"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Slett" })).toBeNull();
+  });
+
+  test("T193: FettMattis table surfaces delete button for recent entries", async () => {
+    const recentEntry = createFettMattis({
+      id: "recent-fettmattis",
+      created_at: new Date().toISOString(),
+    });
+    const onDelete = vi.fn();
+
+    render(
+      <FettmattisTable
+        fettMattis={[recentEntry]}
+        onDelete={onDelete}
+        emptyMessage="Ingen FettMattis"
+      />,
+    );
+
+    const deleteButton = await screen.findByRole("button", { name: "Slett" });
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith("recent-fettmattis");
+  });
+});


### PR DESCRIPTION
## Summary
- add API endpoints and client helpers to list recent rounds and FettMattis entries
- show the latest rounds and FettMattis activity on the landing page with expandable details
- extend the rounds management page with tables and 24-hour deletion controls for rounds and FettMattis awards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f52d4056b883338c2c98ea4f694581