### PR TITLE
feat: add powertools observability middleware

### DIFF
--- a/src/app/api/fettmattis/[fettmattisId]/route.ts
+++ b/src/app/api/fettmattis/[fettmattisId]/route.ts
@@ -7,51 +7,56 @@ import {
   NotFoundError,
   revokeFettMattis,
 } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function DELETE(
-  req: NextRequest,
-  context: { params: Promise<{ fettmattisId: string }> }
-) {
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
+export const DELETE = withObservability(
+  async (
+    req: NextRequest,
+    context: { params: Promise<{ fettmattisId: string }> },
+  ) => {
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
+      });
+    }
 
-  const { fettmattisId } = await context.params;
+    const { fettmattisId } = await context.params;
 
-  const validation = uuidSchema.safeParse(fettmattisId);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Fettmattis id is invalid.";
-    return badRequest(detail);
-  }
+    const validation = uuidSchema.safeParse(fettmattisId);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Fettmattis id is invalid.";
+      return badRequest(detail);
+    }
 
-  try {
     await revokeFettMattis(fettmattisId);
     return new Response(null, { status: 204 });
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "RevokeFettMattis",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
+      if (error instanceof ForbiddenError) {
+        return createProblemResponse({
+          status: 403,
+          title: "Forbidden",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
       });
-    }
-    if (error instanceof ForbiddenError) {
-      return createProblemResponse({
-        status: 403,
-        title: "Forbidden",
-        detail: error.message,
-      });
-    }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+    },
+  },
+);

--- a/src/app/api/fettmattis/route.ts
+++ b/src/app/api/fettmattis/route.ts
@@ -10,55 +10,60 @@ import {
   listRecentFettMattis,
   NotFoundError,
 } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const query = Object.fromEntries(searchParams.entries());
+export const GET = withObservability(
+  async (req: NextRequest) => {
+    const { searchParams } = new URL(req.url);
+    const query = Object.fromEntries(searchParams.entries());
 
-  const validation = ListQuerySchema.safeParse(query);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
-    return badRequest(detail);
-  }
+    const validation = ListQuerySchema.safeParse(query);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
+      return badRequest(detail);
+    }
 
-  try {
     const fettMattisList = await listRecentFettMattis({
       limit: validation.data.limit,
     });
     return NextResponse.json(fettMattisList.map(toFettMattisResponse));
-  } catch (error) {
-    if (error instanceof ConflictError) {
-      return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
-      });
-    }
+  },
+  {
+    operationName: "ListRecentFettMattis",
+    onError: (error) => {
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
 
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+      return createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
+      });
+    },
+  },
+);
 
 /**
  * POST /api/fettmattis
  * Creates a new fettmattis.
  */
-export async function POST(req: NextRequest) {
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
+export const POST = withObservability(
+  async (req: NextRequest) => {
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
+      });
+    }
 
-  try {
     let body: unknown;
     try {
       body = await req.json();
@@ -85,25 +90,29 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(toFettMattisResponse(newFettmattis), {
       status: 201,
     });
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "CreateFettMattis",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
       });
-    }
-    if (error instanceof ConflictError) {
-      return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
-      });
-    }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+    },
+  },
+);

--- a/src/app/api/leaderboard/fettmattis/route.ts
+++ b/src/app/api/leaderboard/fettmattis/route.ts
@@ -3,34 +3,38 @@ import { NextResponse } from "next/server";
 import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { LeaderboardQuerySchema } from "@/lib/api/schemas";
 import { getFettMattisLeaderboard } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const query = Object.fromEntries(searchParams.entries());
+export const GET = withObservability(
+  async (req: Request) => {
+    const { searchParams } = new URL(req.url);
+    const query = Object.fromEntries(searchParams.entries());
 
-  const validation = LeaderboardQuerySchema.safeParse(query);
+    const validation = LeaderboardQuerySchema.safeParse(query);
 
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Invalid leaderboard query.";
-    return badRequest(detail);
-  }
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Invalid leaderboard query.";
+      return badRequest(detail);
+    }
 
-  const requestedYear = validation.data.year;
-  const fallbackYear = new Date().getFullYear();
-  const year = requestedYear === "all" ? null : (requestedYear ?? fallbackYear);
+    const requestedYear = validation.data.year;
+    const fallbackYear = new Date().getFullYear();
+    const year = requestedYear === "all" ? null : (requestedYear ?? fallbackYear);
 
-  try {
     const leaderboard = await getFettMattisLeaderboard(year);
     return NextResponse.json(leaderboard.map(toFettMattisResponse));
-  } catch (error) {
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: error instanceof Error ? error.message : undefined,
-    });
-  }
-}
+  },
+  {
+    operationName: "GetFettMattisLeaderboard",
+    onError: (error) =>
+      createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: error instanceof Error ? error.message : undefined,
+      }),
+  },
+);
 
 function toFettMattisResponse(entry: {
   rank: number;

--- a/src/app/api/leaderboard/regular/route.ts
+++ b/src/app/api/leaderboard/regular/route.ts
@@ -3,34 +3,38 @@ import { NextResponse } from "next/server";
 import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { LeaderboardQuerySchema } from "@/lib/api/schemas";
 import { getRegularLeaderboard } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const query = Object.fromEntries(searchParams.entries());
+export const GET = withObservability(
+  async (req: Request) => {
+    const { searchParams } = new URL(req.url);
+    const query = Object.fromEntries(searchParams.entries());
 
-  const validation = LeaderboardQuerySchema.safeParse(query);
+    const validation = LeaderboardQuerySchema.safeParse(query);
 
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Invalid leaderboard query.";
-    return badRequest(detail);
-  }
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Invalid leaderboard query.";
+      return badRequest(detail);
+    }
 
-  const requestedYear = validation.data.year;
-  const fallbackYear = new Date().getFullYear();
-  const year = requestedYear === "all" ? null : (requestedYear ?? fallbackYear);
+    const requestedYear = validation.data.year;
+    const fallbackYear = new Date().getFullYear();
+    const year = requestedYear === "all" ? null : (requestedYear ?? fallbackYear);
 
-  try {
     const leaderboard = await getRegularLeaderboard(year);
     return NextResponse.json(leaderboard.map(toRegularLeaderboardResponse));
-  } catch (error) {
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: error instanceof Error ? error.message : undefined,
-    });
-  }
-}
+  },
+  {
+    operationName: "GetRegularLeaderboard",
+    onError: (error) =>
+      createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: error instanceof Error ? error.message : undefined,
+      }),
+  },
+);
 
 function toRegularLeaderboardResponse(entry: {
   rank: number;

--- a/src/app/api/leaderboard/seasons/route.ts
+++ b/src/app/api/leaderboard/seasons/route.ts
@@ -2,16 +2,20 @@ import { NextResponse } from "next/server";
 
 import { createProblemResponse } from "@/lib/api/problem-details";
 import { getLeaderboardSeasons } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET() {
-  try {
+export const GET = withObservability(
+  async () => {
     const seasons = await getLeaderboardSeasons();
     return NextResponse.json({ seasons });
-  } catch (error) {
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: error instanceof Error ? error.message : undefined,
-    });
-  }
-}
+  },
+  {
+    operationName: "GetLeaderboardSeasons",
+    onError: (error) =>
+      createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: error instanceof Error ? error.message : undefined,
+      }),
+  },
+);

--- a/src/app/api/players/[playerId]/route.ts
+++ b/src/app/api/players/[playerId]/route.ts
@@ -9,63 +9,68 @@ import {
   NotFoundError,
   updatePlayer,
 } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET(
-  _req: Request,
-  context: { params: Promise<{ playerId: string }> },
-) {
-  const { playerId } = await context.params;
+export const GET = withObservability(
+  async (
+    _req: Request,
+    context: { params: Promise<{ playerId: string }> },
+  ) => {
+    const { playerId } = await context.params;
 
-  const validation = uuidSchema.safeParse(playerId);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Player id is invalid.";
-    return badRequest(detail);
-  }
+    const validation = uuidSchema.safeParse(playerId);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Player id is invalid.";
+      return badRequest(detail);
+    }
 
-  try {
     const player = await getPlayerById(playerId);
 
     return NextResponse.json(toPlayerResponse(player));
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "GetPlayer",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
+      });
+    },
+  },
+);
+
+export const PUT = withObservability(
+  async (
+    req: Request,
+    context: { params: Promise<{ playerId: string }> },
+  ) => {
+    const { playerId } = await context.params;
+
+    const validation = uuidSchema.safeParse(playerId);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Player id is invalid.";
+      return badRequest(detail);
+    }
+
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
       });
     }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
 
-export async function PUT(
-  req: Request,
-  context: { params: Promise<{ playerId: string }> },
-) {
-  const { playerId } = await context.params;
-
-  const validation = uuidSchema.safeParse(playerId);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Player id is invalid.";
-    return badRequest(detail);
-  }
-
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
-
-  try {
     const body = (await req.json()) as unknown;
     const bodyValidation = PlayerUpdateSchema.safeParse(body);
 
@@ -84,25 +89,29 @@ export async function PUT(
     });
 
     return NextResponse.json(toPlayerResponse(updatedPlayer));
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "UpdatePlayer",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
       });
-    }
-    if (error instanceof ConflictError) {
-      return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
-      });
-    }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+    },
+  },
+);

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -5,18 +5,19 @@ import { toPlayerResponse } from "@/lib/api/response-helpers";
 import { PlayerCreateSchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
 import { ConflictError, createPlayer, listPlayers } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function POST(req: Request) {
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
+export const POST = withObservability(
+  async (req: Request) => {
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
+      });
+    }
 
-  try {
     const body = (await req.json()) as unknown;
     const validation = PlayerCreateSchema.safeParse(body);
 
@@ -35,32 +36,39 @@ export async function POST(req: Request) {
     });
 
     return NextResponse.json(toPlayerResponse(newPlayer), { status: 201 });
-  } catch (error) {
-    if (error instanceof ConflictError) {
+  },
+  {
+    operationName: "CreatePlayer",
+    onError: (error) => {
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
+
       return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: error instanceof Error ? error.message : undefined,
       });
-    }
+    },
+  },
+);
 
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: error instanceof Error ? error.message : undefined,
-    });
-  }
-}
-
-export async function GET(_req: Request) {
-  try {
+export const GET = withObservability(
+  async (_req: Request) => {
     const allPlayers = await listPlayers();
     return NextResponse.json(allPlayers.map(toPlayerResponse));
-  } catch (error) {
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: error instanceof Error ? error.message : undefined,
-    });
-  }
-}
+  },
+  {
+    operationName: "ListPlayers",
+    onError: (error) =>
+      createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: error instanceof Error ? error.message : undefined,
+      }),
+  },
+);

--- a/src/app/api/rounds/[roundId]/route.ts
+++ b/src/app/api/rounds/[roundId]/route.ts
@@ -12,158 +12,171 @@ import {
   NotFoundError,
   updateRound,
 } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET(
-  _req: Request,
-  context: { params: Promise<{ roundId: string }> }
-) {
-  const { roundId } = await context.params;
+export const GET = withObservability(
+  async (
+    _req: Request,
+    context: { params: Promise<{ roundId: string }> },
+  ) => {
+    const { roundId } = await context.params;
 
-  const validation = uuidSchema.safeParse(roundId);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Round id is invalid.";
-    return badRequest(detail);
-  }
+    const validation = uuidSchema.safeParse(roundId);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Round id is invalid.";
+      return badRequest(detail);
+    }
 
-  try {
     const round = await getRoundById(roundId);
 
     return NextResponse.json(toRoundResponse(round));
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "GetRound",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
+      });
+    },
+  },
+);
+
+export const PUT = withObservability(
+  async (
+    req: NextRequest,
+    context: { params: Promise<{ roundId: string }> },
+  ) => {
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
       });
     }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
 
-export async function PUT(
-  req: NextRequest,
-  context: { params: Promise<{ roundId: string }> }
-) {
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
+    const { roundId } = await context.params;
 
-  const { roundId } = await context.params;
+    const validation = uuidSchema.safeParse(roundId);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Round id is invalid.";
+      return badRequest(detail);
+    }
 
-  const validation = uuidSchema.safeParse(roundId);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Round id is invalid.";
-    return badRequest(detail);
-  }
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return badRequest("Malformed JSON in request body.");
+    }
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return badRequest("Malformed JSON in request body.");
-  }
+    const parsedBody = RoundUpdateSchema.safeParse(body);
+    if (!parsedBody.success) {
+      const detail =
+        parsedBody.error.issues.at(0)?.message ??
+        "Request body validation failed.";
+      return badRequest(detail);
+    }
 
-  const parsedBody = RoundUpdateSchema.safeParse(body);
-  if (!parsedBody.success) {
-    const detail =
-      parsedBody.error.issues.at(0)?.message ??
-      "Request body validation failed.";
-    return badRequest(detail);
-  }
-
-  try {
     const updatedRound = await updateRound(roundId, {
       participantIds: parsedBody.data.participant_ids,
       loserId: parsedBody.data.loser_id,
     });
 
     return NextResponse.json(toRoundResponse(updatedRound));
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "UpdateRound",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
+      if (error instanceof ForbiddenError) {
+        return createProblemResponse({
+          status: 403,
+          title: "Forbidden",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
+      });
+    },
+  },
+);
+
+export const DELETE = withObservability(
+  async (
+    req: NextRequest,
+    context: { params: Promise<{ roundId: string }> },
+  ) => {
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
       });
     }
-    if (error instanceof ConflictError) {
-      return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
-      });
+
+    const { roundId } = await context.params;
+
+    const validation = uuidSchema.safeParse(roundId);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Round id is invalid.";
+      return badRequest(detail);
     }
-    if (error instanceof ForbiddenError) {
-      return createProblemResponse({
-        status: 403,
-        title: "Forbidden",
-        detail: error.message,
-      });
-    }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
 
-export async function DELETE(
-  req: NextRequest,
-  context: { params: Promise<{ roundId: string }> }
-) {
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
-
-  const { roundId } = await context.params;
-
-  const validation = uuidSchema.safeParse(roundId);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Round id is invalid.";
-    return badRequest(detail);
-  }
-
-  try {
     await deleteRound(roundId);
     return new Response(null, { status: 204 });
-  } catch (error) {
-    if (error instanceof NotFoundError) {
+  },
+  {
+    operationName: "DeleteRound",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
+      if (error instanceof ForbiddenError) {
+        return createProblemResponse({
+          status: 403,
+          title: "Forbidden",
+          detail: error.message,
+        });
+      }
       return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
       });
-    }
-    if (error instanceof ForbiddenError) {
-      return createProblemResponse({
-        status: 403,
-        title: "Forbidden",
-        detail: error.message,
-      });
-    }
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+    },
+  },
+);

--- a/src/app/api/rounds/latest/route.ts
+++ b/src/app/api/rounds/latest/route.ts
@@ -3,9 +3,10 @@ import { NextResponse } from "next/server";
 import { createProblemResponse } from "@/lib/api/problem-details";
 import { toRoundResponse } from "@/lib/api/response-helpers";
 import { getMostRecentRound } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET() {
-  try {
+export const GET = withObservability(
+  async () => {
     const round = await getMostRecentRound();
 
     if (!round) {
@@ -13,11 +14,14 @@ export async function GET() {
     }
 
     return NextResponse.json(toRoundResponse(round));
-  } catch (error) {
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: error instanceof Error ? error.message : undefined,
-    });
-  }
-}
+  },
+  {
+    operationName: "GetMostRecentRound",
+    onError: (error) =>
+      createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: error instanceof Error ? error.message : undefined,
+      }),
+  },
+);

--- a/src/app/api/rounds/route.ts
+++ b/src/app/api/rounds/route.ts
@@ -10,53 +10,58 @@ import {
   listRecentRounds,
   NotFoundError,
 } from "@/lib/db-client";
+import { withObservability } from "@/lib/observability/middleware";
 
-export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const query = Object.fromEntries(searchParams.entries());
+export const GET = withObservability(
+  async (req: NextRequest) => {
+    const { searchParams } = new URL(req.url);
+    const query = Object.fromEntries(searchParams.entries());
 
-  const validation = ListQuerySchema.safeParse(query);
-  if (!validation.success) {
-    const detail =
-      validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
-    return badRequest(detail);
-  }
-
-  try {
-    const rounds = await listRecentRounds({ limit: validation.data.limit });
-    return NextResponse.json(rounds.map(toRoundResponse));
-  } catch (error) {
-    if (error instanceof ConflictError) {
-      return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
-      });
+    const validation = ListQuerySchema.safeParse(query);
+    if (!validation.success) {
+      const detail =
+        validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
+      return badRequest(detail);
     }
 
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+    const rounds = await listRecentRounds({ limit: validation.data.limit });
+    return NextResponse.json(rounds.map(toRoundResponse));
+  },
+  {
+    operationName: "ListRecentRounds",
+    onError: (error) => {
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
+
+      return createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
+      });
+    },
+  },
+);
 
 /**
  * POST /api/rounds
  * Creates a new round.
  */
-export async function POST(req: NextRequest) {
-  const userId = await resolveRequestUserId(req.headers);
-  if (!userId) {
-    return createProblemResponse({
-      status: 401,
-      title: "Unauthorized",
-      detail: "Authentication required.",
-    });
-  }
+export const POST = withObservability(
+  async (req: NextRequest) => {
+    const userId = await resolveRequestUserId(req.headers);
+    if (!userId) {
+      return createProblemResponse({
+        status: 401,
+        title: "Unauthorized",
+        detail: "Authentication required.",
+      });
+    }
 
-  try {
     let body: unknown;
     try {
       body = await req.json();
@@ -82,27 +87,31 @@ export async function POST(req: NextRequest) {
     });
 
     return NextResponse.json(toRoundResponse(newRound), { status: 201 });
-  } catch (error) {
-    if (error instanceof NotFoundError) {
-      return createProblemResponse({
-        status: 404,
-        title: "Not Found",
-        detail: error.message,
-      });
-    }
+  },
+  {
+    operationName: "CreateRound",
+    onError: (error) => {
+      if (error instanceof NotFoundError) {
+        return createProblemResponse({
+          status: 404,
+          title: "Not Found",
+          detail: error.message,
+        });
+      }
 
-    if (error instanceof ConflictError) {
-      return createProblemResponse({
-        status: 409,
-        title: "Conflict",
-        detail: error.message,
-      });
-    }
+      if (error instanceof ConflictError) {
+        return createProblemResponse({
+          status: 409,
+          title: "Conflict",
+          detail: error.message,
+        });
+      }
 
-    return createProblemResponse({
-      status: 500,
-      title: "Internal Server Error",
-      detail: "Internal Server Error",
-    });
-  }
-}
+      return createProblemResponse({
+        status: 500,
+        title: "Internal Server Error",
+        detail: "Internal Server Error",
+      });
+    },
+  },
+);

--- a/src/lib/observability/middleware.ts
+++ b/src/lib/observability/middleware.ts
@@ -1,0 +1,110 @@
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+
+import { logger, metrics, tracer } from "./powertools";
+
+type RequestLike = Request;
+
+const isRequestLike = (value: unknown): value is RequestLike => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const maybeRequest = value as { method?: unknown; url?: unknown };
+  return typeof maybeRequest.method === "string" && typeof maybeRequest.url === "string";
+};
+
+interface ObservabilityOptions<TArgs extends unknown[], TResponse> {
+  operationName?: string;
+  metricName?: string;
+  dimensions?:
+    | Record<string, string>
+    | ((request: RequestLike | undefined, args: TArgs) => Record<string, string>);
+  onError?: (
+    error: unknown,
+    request: RequestLike | undefined,
+    args: TArgs,
+  ) => TResponse | Promise<TResponse>;
+}
+
+export function withObservability<TArgs extends unknown[], TResponse>(
+  handler: (...args: TArgs) => Promise<TResponse>,
+  options: ObservabilityOptions<TArgs, TResponse> = {},
+): (...args: TArgs) => Promise<TResponse> {
+  const {
+    operationName = handler.name || "handler",
+    metricName = "HandlerLatency",
+    dimensions,
+    onError,
+  } = options;
+
+  return async function observableHandler(...args: TArgs): Promise<TResponse> {
+    const request = isRequestLike(args[0]) ? (args[0] as RequestLike) : undefined;
+    const startTime = process.hrtime.bigint();
+    const requestUrl = request ? new URL(request.url) : undefined;
+    const requestId = request?.headers.get("x-request-id") ?? undefined;
+    const userAgent = request?.headers.get("user-agent") ?? undefined;
+    const method = request?.method ?? "UNKNOWN";
+    const path = requestUrl?.pathname ?? `/${operationName}`;
+
+    const logContextEntries = Object.entries({
+      httpMethod: method,
+      path,
+      requestId,
+    }).filter(([, value]) => value !== undefined);
+    if (logContextEntries.length > 0) {
+      logger.appendKeys(Object.fromEntries(logContextEntries));
+    }
+
+    tracer.putAnnotation("operation", operationName);
+    tracer.putAnnotation("httpMethod", method);
+    tracer.putAnnotation("path", path);
+    if (requestId) {
+      tracer.putAnnotation("requestId", requestId);
+    }
+    tracer.putMetadata("request", {
+      method,
+      path,
+      requestId,
+      userAgent,
+    });
+
+    try {
+      const result = await tracer.provider.captureAsyncFunc(
+        operationName,
+        async () => handler(...args),
+      );
+      return result as TResponse;
+    } catch (error) {
+      tracer.addErrorAsMetadata(error as Error);
+      if (onError) {
+        return await onError(error, request, args);
+      }
+      throw error;
+    } finally {
+      const endTime = process.hrtime.bigint();
+      const latencyMs = Number(endTime - startTime) / 1_000_000;
+
+      metrics.addDimension("Operation", operationName);
+      const resolvedDimensions =
+        typeof dimensions === "function" ? dimensions(request, args) : dimensions;
+      if (resolvedDimensions) {
+        for (const [name, value] of Object.entries(resolvedDimensions)) {
+          metrics.addDimension(name, value);
+        }
+      }
+
+      metrics.addMetric(metricName, MetricUnit.Milliseconds, latencyMs);
+      metrics.addMetadata("operation", operationName);
+      metrics.addMetadata("httpMethod", method);
+      metrics.addMetadata("path", path);
+      if (requestId) {
+        metrics.addMetadata("requestId", requestId);
+      }
+      metrics.publishStoredMetrics();
+
+      if (logContextEntries.length > 0) {
+        logger.removeKeys(logContextEntries.map(([key]) => key));
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `withObservability` helper that traces, logs, and records metrics around API handlers
- wrap all API route handlers to use the shared middleware while preserving existing problem response behaviour

## Testing
- npm run tsc
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5e01cb09c833393a3c8ce33574e0c