### PR TITLE
Fix lambda function URL auth configuration

### DIFF
--- a/docs/aws-lambda-web-adapter.md
+++ b/docs/aws-lambda-web-adapter.md
@@ -3,23 +3,22 @@
 Historically we configured the Lambda Web Adapter's `AWS_LWA_AUTHORIZATION_SOURCE`
 to work around the IAM-only `Authorization` header that Lambda Function URLs use
 when SigV4 signing is enabled. POST requests signed by CloudFront started failing
-with `InvalidSignatureException`, so we now expose the function URL with
-`auth_type = NONE` and rely on the Lambda resource policy (restricted to
-CloudFront) for protection. With IAM out of the path the adapter receives the
-viewer `Authorization` header directly and no longer needs a remapped header.
+with `InvalidSignatureException`, so we temporarily exposed the function URL with
+`auth_type = NONE` and relied on the Lambda resource policy (restricted to
+CloudFront) for protection. That change let the adapter receive the viewer
+`Authorization` header directly and removed the need for a remapped header.
 
-This setup follows AWS' Function URL guidance that recommends locking down
-`auth_type = NONE` URLs with a resource policy
-([docs](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html#urls-auth-type-none-policy)).
-The policy we attach in `iac/main.tf:166-173` allows only our CloudFront
-distribution (principal `cloudfront.amazonaws.com` scoped to the distribution
-ARN) to invoke the URL, so the Lambda endpoint is still unreachable from the
-public internet. Because AWS now requires both `lambda:InvokeFunctionUrl` and
-`lambda:InvokeFunction` permissions for new Function URLs, we grant CloudFront
-the second action in `iac/main.tf:175-183`. Even without the explicit
-`lambda:InvokedViaFunctionUrl` condition (Terraform no longer supports
-expressing it), the statement remains limited to this distribution through the
-`source_arn`.
+AWS now enforces IAM authorization for Function URLs that are fronted by
+CloudFront origin access control, so we reverted to `auth_type = AWS_IAM` and
+restored `AWS_LWA_AUTHORIZATION_SOURCE` in `iac/main.tf` to map the
+`X-Amzn-Original-Authorization` header that CloudFront preserves after signing
+the origin request. The resource policy in `iac/main.tf:170-185` still limits
+invocation to our distribution (principal `cloudfront.amazonaws.com` scoped to
+the distribution ARN) and we continue to grant the companion
+`lambda:InvokeFunction` permission that AWS requires for new Function URLs.
+This keeps us aligned with AWS' Function URL guidance to pair IAM auth with
+least-privilege resource policies
+([docs](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html#urls-auth-type-iam-policy)).
 
 If we need an additional safeguard in the future we can ask CloudFront to inject
 a shared secret header and verify it before processing the request, but it is

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -70,6 +70,7 @@ module "fn" {
       AWS_LAMBDA_EXEC_WRAPPER        = "/opt/bootstrap"
       AWS_LWA_ASYNC_INIT             = "true"
       AWS_LWA_ENABLE_COMPRESSION     = "true"
+      AWS_LWA_AUTHORIZATION_SOURCE   = "X-Amzn-Original-Authorization"
       NODE_ENV                       = "production"
       PORT                           = "3000"
       DATABASE_URL                   = local.database_url
@@ -81,7 +82,7 @@ module "fn" {
   )
 
   create_lambda_function_url        = true
-  authorization_type                = "NONE"
+  authorization_type                = "AWS_IAM"
   cloudwatch_logs_retention_in_days = var.lambda_log_retention_days
   tags                              = local.default_tags
 }
@@ -172,7 +173,7 @@ resource "aws_lambda_permission" "allow_cloudfront" {
   function_name          = module.fn.lambda_function_name
   principal              = "cloudfront.amazonaws.com"
   source_arn             = aws_cloudfront_distribution.cdn.arn
-  function_url_auth_type = "NONE"
+  function_url_auth_type = "AWS_IAM"
 }
 
 resource "aws_lambda_permission" "allow_cloudfront_invoke" {


### PR DESCRIPTION
## Summary
- switch the Lambda Function URL back to AWS_IAM authentication and keep the CloudFront-only invoke policy aligned
- restore the Lambda Web Adapter authorization header mapping and document the IAM setup requirements

## Testing
- not run (infrastructure-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f63f93f28c8333a45a81d616624829