### PR TITLE
fix: extend session duration

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -23,5 +23,9 @@ export const auth = betterAuth({
     cookieCache: {
       enabled: !config.IS_TEST,
     },
+    // Keep sessions active for as long as possible so users are not logged out.
+    // 365 days aligns with the maximum duration recommended in the Better Auth docs.
+    expiresIn: 60 * 60 * 24 * 365,
+    updateAge: 60 * 60 * 24,
   },
 });


### PR DESCRIPTION
## Summary
- set the Better Auth session expiration to one year to keep users signed in longer
- refresh active sessions daily so they continue to roll forward

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f67f76ba9483339102a8ffc6a81c07