### PR TITLE
feat: add structured logging to api routes

### DIFF
--- a/src/app/api/fettmattis/route.ts
+++ b/src/app/api/fettmattis/route.ts
@@ -10,8 +10,15 @@ import {
   listRecentFettMattis,
   NotFoundError,
 } from "@/lib/db-client";
+import {
+  getErrorLogContext,
+  getRequestLogContext,
+} from "@/lib/observability/logging";
+import { logger } from "@/lib/observability/powertools";
 
 export async function GET(req: NextRequest) {
+  const requestContext = getRequestLogContext(req);
+  logger.info("Received request to list fettmattis", requestContext);
   const { searchParams } = new URL(req.url);
   const query = Object.fromEntries(searchParams.entries());
 
@@ -19,6 +26,10 @@ export async function GET(req: NextRequest) {
   if (!validation.success) {
     const detail =
       validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
+    logger.warn("Invalid query parameters for fettmattis list", {
+      ...requestContext,
+      query,
+    });
     return badRequest(detail);
   }
 
@@ -26,15 +37,29 @@ export async function GET(req: NextRequest) {
     const fettMattisList = await listRecentFettMattis({
       limit: validation.data.limit,
     });
+    logger.info("Returning fettmattis", {
+      ...requestContext,
+      count: fettMattisList.length,
+      limit: validation.data.limit,
+    });
     return NextResponse.json(fettMattisList.map(toFettMattisResponse));
   } catch (error) {
     if (error instanceof ConflictError) {
+      logger.warn("Conflict while listing fettmattis", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+      });
       return createProblemResponse({
         status: 409,
         title: "Conflict",
         detail: error.message,
       });
     }
+
+    logger.error("Failed to list fettmattis", {
+      ...requestContext,
+      error: getErrorLogContext(error),
+    });
 
     return createProblemResponse({
       status: 500,
@@ -49,8 +74,11 @@ export async function GET(req: NextRequest) {
  * Creates a new fettmattis.
  */
 export async function POST(req: NextRequest) {
+  const requestContext = getRequestLogContext(req);
+  logger.info("Received request to create fettmattis", requestContext);
   const userId = await resolveRequestUserId(req.headers);
   if (!userId) {
+    logger.warn("Unauthorized request to create fettmattis", requestContext);
     return createProblemResponse({
       status: 401,
       title: "Unauthorized",
@@ -58,11 +86,17 @@ export async function POST(req: NextRequest) {
     });
   }
 
+  let playerId: string | undefined;
   try {
     let body: unknown;
     try {
       body = await req.json();
-    } catch {
+    } catch (error) {
+      logger.warn("Malformed JSON in fettmattis create request", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+      });
       return badRequest("Malformed JSON in request body.");
     }
 
@@ -72,14 +106,26 @@ export async function POST(req: NextRequest) {
       const detail =
         validatedData.error.issues.at(0)?.message ??
         "Request body validation failed.";
+      logger.warn("Validation failed for fettmattis creation", {
+        ...requestContext,
+        error: getErrorLogContext(validatedData.error),
+        userId,
+      });
       return badRequest(detail);
     }
 
-    const { player_id: playerId } = validatedData.data;
+    ({ player_id: playerId } = validatedData.data);
 
     const newFettmattis = await createFettMattis({
       playerId,
       createdBy: userId,
+    });
+
+    logger.info("Fettmattis created", {
+      ...requestContext,
+      fettMattisId: newFettmattis.id,
+      userId,
+      playerId,
     });
 
     return NextResponse.json(toFettMattisResponse(newFettmattis), {
@@ -87,6 +133,12 @@ export async function POST(req: NextRequest) {
     });
   } catch (error) {
     if (error instanceof NotFoundError) {
+      logger.warn("Fettmattis creation failed due to missing resource", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+        playerId,
+      });
       return createProblemResponse({
         status: 404,
         title: "Not Found",
@@ -94,12 +146,24 @@ export async function POST(req: NextRequest) {
       });
     }
     if (error instanceof ConflictError) {
+      logger.warn("Conflict while creating fettmattis", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+        playerId,
+      });
       return createProblemResponse({
         status: 409,
         title: "Conflict",
         detail: error.message,
       });
     }
+    logger.error("Failed to create fettmattis", {
+      ...requestContext,
+      error: getErrorLogContext(error),
+      userId,
+      playerId,
+    });
     return createProblemResponse({
       status: 500,
       title: "Internal Server Error",

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -5,10 +5,19 @@ import { toPlayerResponse } from "@/lib/api/response-helpers";
 import { PlayerCreateSchema } from "@/lib/api/schemas";
 import { resolveRequestUserId } from "@/lib/auth/request-user";
 import { ConflictError, createPlayer, listPlayers } from "@/lib/db-client";
+import {
+  getErrorLogContext,
+  getRequestLogContext,
+} from "@/lib/observability/logging";
+import { logger } from "@/lib/observability/powertools";
 
 export async function POST(req: Request) {
+  const requestContext = getRequestLogContext(req);
+  logger.info("Received request to create player", requestContext);
+
   const userId = await resolveRequestUserId(req.headers);
   if (!userId) {
+    logger.warn("Unauthorized request to create player", requestContext);
     return createProblemResponse({
       status: 401,
       title: "Unauthorized",
@@ -24,6 +33,11 @@ export async function POST(req: Request) {
       const detail =
         validation.error.issues.at(0)?.message ??
         "Request body validation failed.";
+      logger.warn("Validation failed for player creation", {
+        ...requestContext,
+        error: getErrorLogContext(validation.error),
+        userId,
+      });
       return badRequest(detail);
     }
 
@@ -34,15 +48,32 @@ export async function POST(req: Request) {
       userId,
     });
 
+    logger.info("Player created", {
+      ...requestContext,
+      playerId: newPlayer.id,
+      userId,
+    });
+
     return NextResponse.json(toPlayerResponse(newPlayer), { status: 201 });
   } catch (error) {
     if (error instanceof ConflictError) {
+      logger.warn("Conflict while creating player", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+      });
       return createProblemResponse({
         status: 409,
         title: "Conflict",
         detail: error.message,
       });
     }
+
+    logger.error("Failed to create player", {
+      ...requestContext,
+      error: getErrorLogContext(error),
+      userId,
+    });
 
     return createProblemResponse({
       status: 500,
@@ -52,11 +83,21 @@ export async function POST(req: Request) {
   }
 }
 
-export async function GET(_req: Request) {
+export async function GET(req: Request) {
+  const requestContext = getRequestLogContext(req);
+  logger.info("Received request to list players", requestContext);
   try {
     const allPlayers = await listPlayers();
+    logger.info("Returning players", {
+      ...requestContext,
+      count: allPlayers.length,
+    });
     return NextResponse.json(allPlayers.map(toPlayerResponse));
   } catch (error) {
+    logger.error("Failed to list players", {
+      ...requestContext,
+      error: getErrorLogContext(error),
+    });
     return createProblemResponse({
       status: 500,
       title: "Internal Server Error",

--- a/src/app/api/rounds/route.ts
+++ b/src/app/api/rounds/route.ts
@@ -10,8 +10,15 @@ import {
   listRecentRounds,
   NotFoundError,
 } from "@/lib/db-client";
+import {
+  getErrorLogContext,
+  getRequestLogContext,
+} from "@/lib/observability/logging";
+import { logger } from "@/lib/observability/powertools";
 
 export async function GET(req: NextRequest) {
+  const requestContext = getRequestLogContext(req);
+  logger.info("Received request to list rounds", requestContext);
   const { searchParams } = new URL(req.url);
   const query = Object.fromEntries(searchParams.entries());
 
@@ -19,20 +26,38 @@ export async function GET(req: NextRequest) {
   if (!validation.success) {
     const detail =
       validation.error.issues.at(0)?.message ?? "Query parameters are invalid.";
+    logger.warn("Invalid query parameters for rounds list", {
+      ...requestContext,
+      query,
+    });
     return badRequest(detail);
   }
 
   try {
     const rounds = await listRecentRounds({ limit: validation.data.limit });
+    logger.info("Returning rounds", {
+      ...requestContext,
+      count: rounds.length,
+      limit: validation.data.limit,
+    });
     return NextResponse.json(rounds.map(toRoundResponse));
   } catch (error) {
     if (error instanceof ConflictError) {
+      logger.warn("Conflict while listing rounds", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+      });
       return createProblemResponse({
         status: 409,
         title: "Conflict",
         detail: error.message,
       });
     }
+
+    logger.error("Failed to list rounds", {
+      ...requestContext,
+      error: getErrorLogContext(error),
+    });
 
     return createProblemResponse({
       status: 500,
@@ -47,8 +72,11 @@ export async function GET(req: NextRequest) {
  * Creates a new round.
  */
 export async function POST(req: NextRequest) {
+  const requestContext = getRequestLogContext(req);
+  logger.info("Received request to create round", requestContext);
   const userId = await resolveRequestUserId(req.headers);
   if (!userId) {
+    logger.warn("Unauthorized request to create round", requestContext);
     return createProblemResponse({
       status: 401,
       title: "Unauthorized",
@@ -60,7 +88,12 @@ export async function POST(req: NextRequest) {
     let body: unknown;
     try {
       body = await req.json();
-    } catch {
+    } catch (error) {
+      logger.warn("Malformed JSON in rounds create request", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+      });
       return badRequest("Malformed JSON in request body.");
     }
 
@@ -70,6 +103,11 @@ export async function POST(req: NextRequest) {
       const detail =
         validatedData.error.issues.at(0)?.message ??
         "Request body validation failed.";
+      logger.warn("Validation failed for round creation", {
+        ...requestContext,
+        error: getErrorLogContext(validatedData.error),
+        userId,
+      });
       return badRequest(detail);
     }
 
@@ -81,9 +119,21 @@ export async function POST(req: NextRequest) {
       createdBy: userId,
     });
 
+    logger.info("Round created", {
+      ...requestContext,
+      roundId: newRound.id,
+      userId,
+      participantCount: participant_ids.length,
+    });
+
     return NextResponse.json(toRoundResponse(newRound), { status: 201 });
   } catch (error) {
     if (error instanceof NotFoundError) {
+      logger.warn("Round creation failed due to missing resource", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+      });
       return createProblemResponse({
         status: 404,
         title: "Not Found",
@@ -92,12 +142,23 @@ export async function POST(req: NextRequest) {
     }
 
     if (error instanceof ConflictError) {
+      logger.warn("Conflict while creating round", {
+        ...requestContext,
+        error: getErrorLogContext(error),
+        userId,
+      });
       return createProblemResponse({
         status: 409,
         title: "Conflict",
         detail: error.message,
       });
     }
+
+    logger.error("Failed to create round", {
+      ...requestContext,
+      error: getErrorLogContext(error),
+      userId,
+    });
 
     return createProblemResponse({
       status: 500,

--- a/src/lib/observability/logging.ts
+++ b/src/lib/observability/logging.ts
@@ -1,0 +1,35 @@
+import type { NextRequest } from "next/server";
+
+type RequestLike = Pick<Request, "method" | "url" | "headers"> | NextRequest;
+
+type RequestLogContext = {
+  method: string;
+  url: string;
+  requestId?: string;
+};
+
+type ErrorLogContext = {
+  name: string;
+  message: string;
+  stack?: string;
+};
+
+export function getRequestLogContext(request: RequestLike): RequestLogContext {
+  return {
+    method: request.method,
+    url: request.url,
+    requestId: request.headers.get("x-request-id") ?? undefined,
+  };
+}
+
+export function getErrorLogContext(error: unknown): ErrorLogContext | { raw: unknown } {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return { raw: error };
+}


### PR DESCRIPTION
## Summary
- add helpers to build request and error log context for powertools logger usage
- log incoming requests, validation issues, and failure cases in the players, rounds, and fettmattis API routes

## Testing
- npm run lint
- npm run tsc

------
https://chatgpt.com/codex/tasks/task_e_68f67f4034a48333867d23e41011c141