### PR TITLE
fix: improve mobile layout for homepage tables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,10 +6,10 @@
 /* biome-ignore lint/suspicious/noUnknownAtRules: Tailwind CSS utility declaration. */
 @utility container {
   margin-inline: auto;
-  padding-inline: 1.5rem;
+  padding-inline: 1rem;
   /* biome-ignore lint/correctness/noUnknownFunction: Tailwind CSS theme breakpoint lookup. */
   @media (width >= theme(--breakpoint-sm)) {
-    padding-inline: 2rem;
+    padding-inline: 1.5rem;
   }
   /* biome-ignore lint/correctness/noUnknownFunction: Tailwind CSS theme breakpoint lookup. */
   @media (width >= theme(--breakpoint-lg)) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
   padding-inline: 1rem;
   /* biome-ignore lint/correctness/noUnknownFunction: Tailwind CSS theme breakpoint lookup. */
   @media (width >= theme(--breakpoint-sm)) {
-    padding-inline: 1.5rem;
+    padding-inline: 2rem;
   }
   /* biome-ignore lint/correctness/noUnknownFunction: Tailwind CSS theme breakpoint lookup. */
   @media (width >= theme(--breakpoint-lg)) {
@@ -155,9 +155,7 @@
     color: hsl(var(--foreground));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    font-feature-settings:
-      "rlig" 1,
-      "calt" 1;
+    font-feature-settings: "rlig" 1, "calt" 1;
   }
 
   ::selection {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -127,7 +127,7 @@ export default async function Home() {
                   <Link href="/rounds">Se alle runder</Link>
                 </Button>
               </CardHeader>
-              <CardContent>
+              <CardContent className="p-4 pt-2 sm:p-6 sm:pt-4">
                 <RoundsTable
                   rounds={roundsForDisplay}
                   emptyMessage="Ingen runder er registrert ennå."
@@ -147,7 +147,7 @@ export default async function Home() {
                   <Link href="/rounds">Se tildelinger</Link>
                 </Button>
               </CardHeader>
-              <CardContent>
+              <CardContent className="p-4 pt-2 sm:p-6 sm:pt-4">
                 <FettmattisTable fettMattis={fettMattisForDisplay} />
               </CardContent>
             </Card>

--- a/src/components/fettmattis-table.tsx
+++ b/src/components/fettmattis-table.tsx
@@ -81,8 +81,8 @@ export function FettmattisTable({
       <TableHeader>
         <TableRow>
           <TableHead>Tildelt</TableHead>
-          <TableHead>Spiller</TableHead>
-          <TableHead className="text-right">Handling</TableHead>
+          <TableHead className="hidden sm:table-cell">Spiller</TableHead>
+          <TableHead className="text-left sm:text-right">Handling</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -106,18 +106,18 @@ export function FettmattisTable({
                 <Fragment key={entry.id}>
                   <TableRow>
                     <TableCell>
-                      <div className="flex flex-col">
+                      <div className="flex flex-col gap-1">
                         <span className="font-medium">{formattedDate}</span>
-                        <span className="text-muted-foreground text-xs">
-                          {entry.player.display_name}
-                        </span>
+                        <div className="flex flex-wrap items-center gap-2 sm:hidden">
+                          <Badge>{entry.player.display_name}</Badge>
+                        </div>
                       </div>
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       <Badge className="w-fit">{entry.player.display_name}</Badge>
                     </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex justify-end gap-2">
+                    <TableCell className="text-left sm:text-right">
+                      <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
                         <Button
                           variant="ghost"
                           size="sm"

--- a/src/components/rounds-table.tsx
+++ b/src/components/rounds-table.tsx
@@ -83,11 +83,11 @@ export function RoundsTable({
       <TableHeader>
         <TableRow>
           <TableHead>Registrert</TableHead>
-          <TableHead>Mattis</TableHead>
+          <TableHead className="hidden sm:table-cell">Mattis</TableHead>
           <TableHead className="hidden text-right sm:table-cell">
             Deltakere
           </TableHead>
-          <TableHead className="text-right">Handling</TableHead>
+          <TableHead className="text-left sm:text-right">Handling</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -105,23 +105,26 @@ export function RoundsTable({
 
               return (
                 <Fragment key={round.id}>
-                  <TableRow>
+                  <TableRow className="sm:align-middle">
                     <TableCell>
-                      <div className="flex flex-col">
+                      <div className="flex flex-col gap-1">
                         <span className="font-medium">{formattedDate}</span>
+                        <span className="text-muted-foreground text-xs sm:hidden">
+                          {round.loser.display_name}
+                        </span>
                         <span className="text-muted-foreground text-xs sm:hidden">
                           {participantCount} deltakere
                         </span>
                       </div>
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       <span className="font-medium">{round.loser.display_name}</span>
                     </TableCell>
                     <TableCell className="hidden text-right sm:table-cell">
                       {participantCount}
                     </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex justify-end gap-2">
+                    <TableCell className="text-left sm:text-right">
+                      <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
                         <Button
                           variant="ghost"
                           size="sm"

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -8,7 +8,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, children, ...props }, ref) => (
-  <div className="border-border/60 bg-card relative w-full overflow-hidden rounded-3xl border shadow-xs">
+  <div className="border-border/60 bg-card relative w-full overflow-x-auto rounded-3xl border shadow-xs">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}
@@ -85,7 +85,7 @@ const TableHead = React.forwardRef<
     ref={ref}
     scope={scope}
     className={cn(
-      "text-muted-foreground px-6 py-3 text-left font-semibold",
+      "text-muted-foreground px-4 py-3 text-left font-semibold sm:px-6",
       className,
     )}
     {...props}
@@ -99,7 +99,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("px-6 py-4 align-middle text-sm", className)}
+    className={cn("px-4 py-4 align-middle text-sm sm:px-6", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- reduce container padding on smaller screens to use more viewport width
- tweak rounds and FettMattis tables to stack key info and align controls on mobile
- relax table padding and enable horizontal scrolling to prevent cramped layouts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7318e7ba48333b933cfa82a1aff56