### PR TITLE
chore: migrate middleware to proxy entrypoint

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,7 +21,7 @@ const ALLOWED_METHODS = [
 
 const UNPROTECTED_PATHS = [/^\/api\/auth(?:\/|$)/];
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const responseHeaders = new Headers();
   const trustedOrigins = getTrustedOrigins(request);
   const origin = request.headers.get("origin");
@@ -89,5 +89,4 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: ["/api/:path*"],
-  runtime: "nodejs",
 };


### PR DESCRIPTION
## Summary
- rename the Next.js middleware entrypoint to the new proxy.ts file
- rename the exported handler to `proxy` and rely on the default Node.js runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900abf890148333a7f56752336b80e0