### PR TITLE
refactor(iac): inline Route53 app records

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -184,40 +184,38 @@ resource "aws_lambda_permission" "allow_cloudfront" {
   function_url_auth_type = "AWS_IAM"
 }
 
-module "dns_records" {
-  source  = "terraform-aws-modules/route53/aws"
-  version = "6.1.0"
+resource "aws_route53_record" "app_a" {
+  zone_id         = data.aws_route53_zone.zone.zone_id
+  name            = var.app_domain
+  type            = "A"
+  allow_overwrite = true
 
-  create       = true
-  create_zone  = false
-  name         = data.aws_route53_zone.zone.name
-  private_zone = false
-
-  records = {
-    app_a = {
-      full_name       = var.app_domain
-      type            = "A"
-      allow_overwrite = true
-      alias = {
-        name                   = module.cdn.cloudfront_distribution_domain_name
-        zone_id                = module.cdn.cloudfront_distribution_hosted_zone_id
-        evaluate_target_health = false
-      }
-    }
-
-    app_aaaa = {
-      full_name       = var.app_domain
-      type            = "AAAA"
-      allow_overwrite = true
-      alias = {
-        name                   = module.cdn.cloudfront_distribution_domain_name
-        zone_id                = module.cdn.cloudfront_distribution_hosted_zone_id
-        evaluate_target_health = false
-      }
-    }
+  alias {
+    name                   = module.cdn.cloudfront_distribution_domain_name
+    zone_id                = module.cdn.cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = false
   }
+}
 
-  tags = local.default_tags
+resource "aws_route53_record" "app_aaaa" {
+  zone_id         = data.aws_route53_zone.zone.zone_id
+  name            = var.app_domain
+  type            = "AAAA"
+  allow_overwrite = true
 
-  depends_on = [module.cdn]
+  alias {
+    name                   = module.cdn.cloudfront_distribution_domain_name
+    zone_id                = module.cdn.cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+moved {
+  from = module.dns_records.aws_route53_record.this["app_a"]
+  to   = aws_route53_record.app_a
+}
+
+moved {
+  from = module.dns_records.aws_route53_record.this["app_aaaa"]
+  to   = aws_route53_record.app_aaaa
 }


### PR DESCRIPTION
## Summary
- replace the Route53 module with direct app A/AAAA records
- add Terraform moved blocks so existing records are adopted without recreation

## Testing
- not run (infra change only)