### PR TITLE
Align OpenAPI with OWASP Spectral rules

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,5 +1,7 @@
 extends:
   - spectral:oas
+  - "@stoplight/spectral-owasp-ruleset"
+  - ./spectral/owasp-api-governance/.spectral.yaml
 
 rules:
   operation-operationId: error

--- a/e2e/app-flows.spec.ts
+++ b/e2e/app-flows.spec.ts
@@ -5,7 +5,7 @@ import { loginAsTestUser } from "./helpers/auth";
 
 type ApiPlayer = components["schemas"]["Player"];
 type ApiRound = components["schemas"]["Round"];
-type ApiFettMattis = components["schemas"]["FettMattis"];
+type ApiFettmattis = components["schemas"]["Fettmattis"];
 
 const ASTRID = "Astrid Nygaard";
 const EMIL = "Emil Kavli";
@@ -141,7 +141,7 @@ test("T037: user can toggle player activity from the roster", async ({
   ).toBeVisible();
 });
 
-test("T037: leaderboard view surfaces regular and FettMattis standings", async ({
+test("T037: leaderboard view surfaces regular and Fettmattis standings", async ({
   page,
 }) => {
   await page.goto("/leaderboard", { waitUntil: "domcontentloaded" });
@@ -163,18 +163,18 @@ test("T037: leaderboard view surfaces regular and FettMattis standings", async (
     regularTable.getByRole("row", { name: new RegExp(LINA, "i") }),
   ).toBeVisible();
 
-  const fettMattisTable = page.getByRole("table").filter({
+  const fettmattisTable = page.getByRole("table").filter({
     has: page.getByRole("columnheader", {
-      name: "FettMattis",
+      name: "Fettmattis",
       exact: true,
     }),
   });
-  await expect(fettMattisTable).toBeVisible();
+  await expect(fettmattisTable).toBeVisible();
   await expect(
-    fettMattisTable.getByRole("row", { name: new RegExp(ASTRID, "i") }),
+    fettmattisTable.getByRole("row", { name: new RegExp(ASTRID, "i") }),
   ).toBeVisible();
   await expect(
-    fettMattisTable.getByRole("row", { name: new RegExp(LINA, "i") }),
+    fettmattisTable.getByRole("row", { name: new RegExp(LINA, "i") }),
   ).toBeVisible();
 });
 
@@ -244,17 +244,17 @@ test("T193: rounds dashboard enforces 24-hour deletion window", async ({
     page.locator(`button[aria-controls="round-details-${latestRound.id}"]`),
   ).toHaveCount(0);
 
-  const archivedFettMattisButton = page.locator(
+  const archivedFettmattisButton = page.locator(
     'button[aria-controls="fettmattis-details-30000000-0000-4000-8000-000000000302"]',
   );
-  await expect(archivedFettMattisButton).toBeVisible();
+  await expect(archivedFettmattisButton).toBeVisible();
 
-  const archivedFettMattisRow = page
+  const archivedFettmattisRow = page
     .locator("tr")
-    .filter({ has: archivedFettMattisButton })
+    .filter({ has: archivedFettmattisButton })
     .first();
   await expect(
-    archivedFettMattisRow.getByRole("button", { name: "Slett" }),
+    archivedFettmattisRow.getByRole("button", { name: "Slett" }),
   ).toHaveCount(0);
 
   await page.getByLabel("Spiller").selectOption({ label: LINA });
@@ -263,48 +263,48 @@ test("T193: rounds dashboard enforces 24-hour deletion window", async ({
     page.getByText("Fettmattis tildelt. Klar for feiring!"),
   ).toBeVisible();
 
-  const fettMattisResponse = await page.request.get("/api/fettmattis?limit=1");
-  expect(fettMattisResponse.ok()).toBeTruthy();
-  const [latestFettMattis] =
-    (await fettMattisResponse.json()) as ApiFettMattis[];
-  if (!latestFettMattis) {
+  const fettmattisResponse = await page.request.get("/api/fettmattis?limit=1");
+  expect(fettmattisResponse.ok()).toBeTruthy();
+  const [latestFettmattis] =
+    (await fettmattisResponse.json()) as ApiFettmattis[];
+  if (!latestFettmattis) {
     throw new Error("Latest Fettmattis entry was not returned after creation.");
   }
 
-  const latestFettMattisDetailsButton = page
+  const latestFettmattisDetailsButton = page
     .locator(
-      `button[aria-controls="fettmattis-details-${latestFettMattis.id}"]`,
+      `button[aria-controls="fettmattis-details-${latestFettmattis.id}"]`,
     )
     .first();
-  const latestFettMattisRow = page
+  const latestFettmattisRow = page
     .locator("tr")
-    .filter({ has: latestFettMattisDetailsButton })
+    .filter({ has: latestFettmattisDetailsButton })
     .first();
-  await latestFettMattisDetailsButton.click();
+  await latestFettmattisDetailsButton.click();
 
-  const latestFettMattisDetails = page.locator(
-    `#fettmattis-details-${latestFettMattis.id}`,
+  const latestFettmattisDetails = page.locator(
+    `#fettmattis-details-${latestFettmattis.id}`,
   );
-  await expect(latestFettMattisDetails).toBeVisible();
+  await expect(latestFettmattisDetails).toBeVisible();
   await expect(
-    latestFettMattisDetails.getByText("Spillerstatus"),
+    latestFettmattisDetails.getByText("Spillerstatus"),
   ).toBeVisible();
   await expect(
-    latestFettMattisDetails.getByText("Endringsvindu"),
+    latestFettmattisDetails.getByText("Endringsvindu"),
   ).toBeVisible();
 
-  const latestFettMattisDeleteButton = latestFettMattisRow.getByRole("button", {
+  const latestFettmattisDeleteButton = latestFettmattisRow.getByRole("button", {
     name: "Slett",
   });
-  await expect(latestFettMattisDeleteButton).toBeVisible();
-  await latestFettMattisDeleteButton.click();
+  await expect(latestFettmattisDeleteButton).toBeVisible();
+  await latestFettmattisDeleteButton.click();
 
   await expect(
     page.getByText("Fettmattis fjernet. Oversikten er oppdatert."),
   ).toBeVisible();
   await expect(
     page.locator(
-      `button[aria-controls="fettmattis-details-${latestFettMattis.id}"]`,
+      `button[aria-controls="fettmattis-details-${latestFettmattis.id}"]`,
     ),
   ).toHaveCount(0);
 });

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -34,25 +34,25 @@ test.describe("Landing Page", () => {
       name: "De siste rundene",
       level: 3,
     });
-    const fettMattisHeading = page.getByRole("heading", {
+    const fettmattisHeading = page.getByRole("heading", {
       name: "Ferske Fettmattiser",
       level: 3,
     });
 
     await expect(roundsHeading).toBeVisible();
-    await expect(fettMattisHeading).toBeVisible();
+    await expect(fettmattisHeading).toBeVisible();
 
     const leaderboardBox = await leaderboardHeading.boundingBox();
     const roundsBox = await roundsHeading.boundingBox();
-    const fettMattisBox = await fettMattisHeading.boundingBox();
+    const fettmattisBox = await fettmattisHeading.boundingBox();
 
-    if (!leaderboardBox || !roundsBox || !fettMattisBox) {
+    if (!leaderboardBox || !roundsBox || !fettmattisBox) {
       throw new Error(
         "Unable to determine layout for leaderboard or activity tables.",
       );
     }
 
     expect(roundsBox.y).toBeGreaterThan(leaderboardBox.y);
-    expect(fettMattisBox.y).toBeGreaterThan(leaderboardBox.y);
+    expect(fettmattisBox.y).toBeGreaterThan(leaderboardBox.y);
   });
 });

--- a/e2e/leaderboard-page.spec.ts
+++ b/e2e/leaderboard-page.spec.ts
@@ -57,21 +57,21 @@ test.describe("Leaderboard Page", () => {
       await expect(regularSection).toBeVisible();
     });
 
-    await test.step("Verify FettMattis leaderboard section", async () => {
+    await test.step("Verify Fettmattis leaderboard section", async () => {
       const fettmattisSection = page
         .getByRole("heading", { name: "Fettmattis-utdelinger" })
         .locator("..");
       await expect(fettmattisSection).toBeVisible();
     });
 
-    await test.step("Verify FettMattis table structure", async () => {
+    await test.step("Verify Fettmattis table structure", async () => {
       // Wait for the page to fully load
       await page.waitForLoadState("networkidle");
 
       const tables = page.getByRole("table");
       const tableCount = await tables.count();
 
-      // Check if we have a second table (FettMattis) or an empty state message
+      // Check if we have a second table (Fettmattis) or an empty state message
       if (tableCount >= 2) {
         const fettmattisTable = tables.nth(1);
         await expect(fettmattisTable).toBeVisible();
@@ -82,7 +82,7 @@ test.describe("Leaderboard Page", () => {
           fettmattisTable.getByRole("columnheader", { name: "Spiller" }),
         ).toBeVisible();
         await expect(
-          fettmattisTable.getByRole("columnheader", { name: "FettMattis" }),
+          fettmattisTable.getByRole("columnheader", { name: "Fettmattis" }),
         ).toBeVisible();
       } else {
         // Verify empty state message is shown

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,8 +22,22 @@ info:
 
     **Error Handling**:
     - The API uses RFC 9457 for problem details in error responses.
+  contact:
+    name: Mattis API Support
+    email: support@mattis.local
 servers:
   - url: /api
+tags:
+  - name: Authentication
+    description: Session and sign-in workflows.
+  - name: Players
+    description: Player roster management.
+  - name: Rounds
+    description: Round recording and history.
+  - name: FettMattis
+    description: FettMattis awards and revocations.
+  - name: Leaderboards
+    description: Leaderboard and season statistics.
 paths:
   /auth/get-session:
     get:
@@ -95,6 +109,7 @@ paths:
   /players:
     get:
       summary: List Players
+      description: Returns all players, ordered by display name.
       operationId: listPlayers
       tags:
         - Players
@@ -110,6 +125,7 @@ paths:
                   $ref: "#/components/schemas/Player"
     post:
       summary: Create Player
+      description: Creates a new player in the roster.
       operationId: createPlayer
       tags:
         - Players
@@ -138,6 +154,7 @@ paths:
   /players/{playerId}:
     get:
       summary: Get Player Details
+      description: Returns details for a single player.
       operationId: getPlayer
       tags:
         - Players
@@ -161,6 +178,7 @@ paths:
           $ref: "#/components/responses/NotFound"
     put:
       summary: Update Player
+      description: Updates player profile fields and status.
       operationId: updatePlayer
       tags:
         - Players
@@ -197,6 +215,7 @@ paths:
   /rounds:
     get:
       summary: List Rounds
+      description: Returns recent rounds, optionally limited by query parameter.
       operationId: listRounds
       tags:
         - Rounds
@@ -220,6 +239,7 @@ paths:
                   $ref: "#/components/schemas/Round"
     post:
       summary: Record a Round
+      description: Records a completed round and updates leaderboards.
       operationId: createRound
       tags:
         - Rounds
@@ -264,6 +284,7 @@ paths:
   /rounds/{roundId}:
     get:
       summary: Get Round Details
+      description: Returns the details of a specific round.
       operationId: getRound
       tags:
         - Rounds
@@ -287,6 +308,7 @@ paths:
           $ref: "#/components/responses/NotFound"
     put:
       summary: Edit a Round (within 24h)
+      description: Updates round participants or the recorded loser within the edit window.
       operationId: updateRound
       tags:
         - Rounds
@@ -325,6 +347,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
     delete:
       summary: Soft Delete a Round (within 24h)
+      description: Soft-deletes a round and removes it from leaderboards.
       operationId: deleteRound
       tags:
         - Rounds
@@ -351,6 +374,7 @@ paths:
   /fettmattis:
     get:
       summary: List FettMattis Entries
+      description: Returns recent FettMattis awards.
       operationId: listFettmattis
       tags:
         - FettMattis
@@ -374,6 +398,7 @@ paths:
                   $ref: "#/components/schemas/FettMattis"
     post:
       summary: Create FettMattis
+      description: Grants a FettMattis award to a player.
       operationId: createFettmattis
       tags:
         - FettMattis
@@ -402,6 +427,7 @@ paths:
   /fettmattis/{fettmattisId}:
     delete:
       summary: Delete FettMattis (within 24h)
+      description: Revokes a FettMattis award within the edit window.
       operationId: deleteFettmattis
       tags:
         - FettMattis
@@ -428,6 +454,7 @@ paths:
   /leaderboard/regular:
     get:
       summary: Get Regular Leaderboard
+      description: Returns leaderboard standings for regular play.
       operationId: getRegularLeaderboard
       tags:
         - Leaderboards
@@ -455,6 +482,7 @@ paths:
   /leaderboard/fettmattis:
     get:
       summary: Get Fettmattis Leaderboard
+      description: Returns leaderboard standings for FettMattis awards.
       operationId: getFettmattisLeaderboard
       tags:
         - Leaderboards
@@ -482,6 +510,7 @@ paths:
   /leaderboard/seasons:
     get:
       summary: List Available Leaderboard Seasons
+      description: Returns the list of seasons with available leaderboard data.
       operationId: listLeaderboardSeasons
       tags:
         - Leaderboards

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,8 +34,8 @@ tags:
     description: Player roster management.
   - name: Rounds
     description: Round recording and history.
-  - name: FettMattis
-    description: FettMattis awards and revocations.
+  - name: Fettmattis
+    description: Fettmattis awards and revocations.
   - name: Leaderboards
     description: Leaderboard and season statistics.
 paths:
@@ -373,11 +373,11 @@ paths:
 
   /fettmattis:
     get:
-      summary: List FettMattis Entries
-      description: Returns recent FettMattis awards.
+      summary: List Fettmattis Entries
+      description: Returns recent Fettmattis awards.
       operationId: listFettmattis
       tags:
-        - FettMattis
+        - Fettmattis
       security: []
       parameters:
         - name: limit
@@ -386,22 +386,22 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-          description: Limit the number of FettMattis entries returned. Defaults to 20 when omitted.
+          description: Limit the number of Fettmattis entries returned. Defaults to 20 when omitted.
       responses:
         "200":
-          description: A list of recent FettMattis entries.
+          description: A list of recent Fettmattis entries.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/FettMattis"
+                  $ref: "#/components/schemas/Fettmattis"
     post:
-      summary: Create FettMattis
-      description: Grants a FettMattis award to a player.
+      summary: Create Fettmattis
+      description: Grants a Fettmattis award to a player.
       operationId: createFettmattis
       tags:
-        - FettMattis
+        - Fettmattis
       security:
         - bearerAuth: []
       requestBody:
@@ -409,14 +409,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/FettMattisCreate"
+              $ref: "#/components/schemas/FettmattisCreate"
       responses:
         "201":
-          description: FettMattis created successfully.
+          description: Fettmattis created successfully.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FettMattis"
+                $ref: "#/components/schemas/Fettmattis"
         "400":
           $ref: "#/components/responses/BadRequest"
         "409":
@@ -426,11 +426,11 @@ paths:
 
   /fettmattis/{fettmattisId}:
     delete:
-      summary: Delete FettMattis (within 24h)
-      description: Revokes a FettMattis award within the edit window.
+      summary: Delete Fettmattis (within 24h)
+      description: Revokes a Fettmattis award within the edit window.
       operationId: deleteFettmattis
       tags:
-        - FettMattis
+        - Fettmattis
       security:
         - bearerAuth: []
       parameters:
@@ -443,7 +443,7 @@ paths:
             description: UUID v7, time-ordered identifier.
       responses:
         "204":
-          description: FettMattis revoked successfully.
+          description: Fettmattis revoked successfully.
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
@@ -482,7 +482,7 @@ paths:
   /leaderboard/fettmattis:
     get:
       summary: Get Fettmattis Leaderboard
-      description: Returns leaderboard standings for FettMattis awards.
+      description: Returns leaderboard standings for Fettmattis awards.
       operationId: getFettmattisLeaderboard
       tags:
         - Leaderboards
@@ -721,7 +721,7 @@ components:
           format: uuid
           description: UUID v7, time-ordered identifier.
 
-    FettMattis:
+    Fettmattis:
       type: object
       required:
         - id
@@ -742,7 +742,7 @@ components:
         created_at:
           type: string
           format: date-time
-    FettMattisCreate:
+    FettmattisCreate:
       type: object
       required:
         - player_id

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,8 +12,8 @@ info:
     - View leaderboards for regular play (loss percentage) and Fettmattis.
 
     **Authentication**:
-    - Write operations (`POST`, `PUT`, `DELETE`) require a bearer token issued by the authentication service.
-    - Read operations (`GET`) are public.
+    - Operations require either a bearer token or a signed session cookie.
+    - Authentication endpoints establish or revoke sessions for clients that are not yet authenticated.
     - The contract defines both a bearer token scheme for API clients and a cookie-based scheme
       for browser sessions. Use the `bearerAuth` security requirement when automating requests
       or calling protected resources from non-browser clients, and the `sessionCookie` requirement
@@ -27,6 +27,7 @@ info:
     email: kenneth@aasan.dev
 servers:
   - url: /api
+    x-internal: false
 tags:
   - name: Authentication
     description: Session and sign-in workflows.
@@ -38,6 +39,9 @@ tags:
     description: Fettmattis awards and revocations.
   - name: Leaderboards
     description: Leaderboard and season statistics.
+security:
+  - bearerAuth: []
+  - sessionCookie: []
 paths:
   /auth/get-session:
     get:
@@ -51,14 +55,29 @@ paths:
       responses:
         "200":
           description: The current session details or null when no session is available.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/AuthSession"
                   - type: "null"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /auth/sign-in/email:
     post:
@@ -67,7 +86,6 @@ paths:
       operationId: signInWithEmail
       tags:
         - Authentication
-      security: []
       requestBody:
         required: true
         content:
@@ -77,6 +95,15 @@ paths:
       responses:
         "200":
           description: Session token and user details for the authenticated user.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
@@ -87,6 +114,10 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /auth/sign-out:
     post:
@@ -100,12 +131,27 @@ paths:
       responses:
         "200":
           description: Confirmation that the session was terminated.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SignOutResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /players:
     get:
       summary: List Players
@@ -113,16 +159,33 @@ paths:
       operationId: listPlayers
       tags:
         - Players
-      security: []
       responses:
         "200":
           description: A list of players.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 type: array
+                maxItems: 200
                 items:
                   $ref: "#/components/schemas/Player"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Player
       description: Creates a new player in the roster.
@@ -140,6 +203,15 @@ paths:
       responses:
         "201":
           description: Player created successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
@@ -150,6 +222,10 @@ paths:
           $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /players/{playerId}:
     get:
@@ -158,7 +234,6 @@ paths:
       operationId: getPlayer
       tags:
         - Players
-      security: []
       parameters:
         - name: playerId
           in: path
@@ -166,16 +241,34 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
       responses:
         "200":
           description: Player details.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Player"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     put:
       summary: Update Player
       description: Updates player profile fields and status.
@@ -191,6 +284,7 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
       requestBody:
         required: true
@@ -201,6 +295,15 @@ paths:
       responses:
         "200":
           description: Player updated successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
@@ -211,6 +314,10 @@ paths:
           $ref: "#/components/responses/NotFound"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /rounds:
     get:
@@ -219,24 +326,42 @@ paths:
       operationId: listRounds
       tags:
         - Rounds
-      security: []
       parameters:
         - name: limit
           in: query
           schema:
             type: integer
+            format: int32
             minimum: 1
             maximum: 100
           description: Limit the number of rounds returned. Defaults to 20 when omitted.
       responses:
         "200":
           description: A list of recent rounds.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 type: array
+                maxItems: 200
                 items:
                   $ref: "#/components/schemas/Round"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Record a Round
       description: Records a completed round and updates leaderboards.
@@ -254,6 +379,15 @@ paths:
       responses:
         "201":
           description: Round created successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
@@ -262,6 +396,10 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /rounds/latest:
     get:
@@ -270,16 +408,32 @@ paths:
       operationId: getLatestRound
       tags:
         - Rounds
-      security: []
       responses:
         "200":
           description: The most recent round or null when no rounds exist.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/Round"
                   - type: "null"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /rounds/{roundId}:
     get:
@@ -288,7 +442,6 @@ paths:
       operationId: getRound
       tags:
         - Rounds
-      security: []
       parameters:
         - name: roundId
           in: path
@@ -296,16 +449,34 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
       responses:
         "200":
           description: Round details.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Round"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     put:
       summary: Edit a Round (within 24h)
       description: Updates round participants or the recorded loser within the edit window.
@@ -321,6 +492,7 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
       requestBody:
         required: true
@@ -331,6 +503,15 @@ paths:
       responses:
         "200":
           description: Round updated successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
@@ -345,6 +526,10 @@ paths:
           $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     delete:
       summary: Soft Delete a Round (within 24h)
       description: Soft-deletes a round and removes it from leaderboards.
@@ -360,16 +545,32 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
       responses:
         "204":
           description: Round deleted successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /fettmattis:
     get:
@@ -378,24 +579,42 @@ paths:
       operationId: listFettmattis
       tags:
         - Fettmattis
-      security: []
       parameters:
         - name: limit
           in: query
           schema:
             type: integer
+            format: int32
             minimum: 1
             maximum: 100
           description: Limit the number of Fettmattis entries returned. Defaults to 20 when omitted.
       responses:
         "200":
           description: A list of recent Fettmattis entries.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 type: array
+                maxItems: 200
                 items:
                   $ref: "#/components/schemas/Fettmattis"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Fettmattis
       description: Grants a Fettmattis award to a player.
@@ -413,6 +632,15 @@ paths:
       responses:
         "201":
           description: Fettmattis created successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
@@ -423,6 +651,10 @@ paths:
           $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /fettmattis/{fettmattisId}:
     delete:
@@ -440,16 +672,32 @@ paths:
           schema:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
       responses:
         "204":
           description: Fettmattis revoked successfully.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /leaderboard/regular:
     get:
@@ -458,13 +706,15 @@ paths:
       operationId: getRegularLeaderboard
       tags:
         - Leaderboards
-      security: []
       parameters:
         - name: year
           in: query
           schema:
             oneOf:
               - type: integer
+                format: int32
+                minimum: 1900
+                maximum: 2100
               - type: string
                 enum:
                   - all
@@ -472,12 +722,30 @@ paths:
       responses:
         "200":
           description: The regular season leaderboard.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 type: array
+                maxItems: 200
                 items:
                   $ref: "#/components/schemas/RegularLeaderboardItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /leaderboard/fettmattis:
     get:
@@ -486,13 +754,15 @@ paths:
       operationId: getFettmattisLeaderboard
       tags:
         - Leaderboards
-      security: []
       parameters:
         - name: year
           in: query
           schema:
             oneOf:
               - type: integer
+                format: int32
+                minimum: 1900
+                maximum: 2100
               - type: string
                 enum:
                   - all
@@ -500,12 +770,30 @@ paths:
       responses:
         "200":
           description: The Fettmattis leaderboard.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 type: array
+                maxItems: 200
                 items:
                   $ref: "#/components/schemas/FettmattisLeaderboardItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /leaderboard/seasons:
     get:
@@ -514,14 +802,30 @@ paths:
       operationId: listLeaderboardSeasons
       tags:
         - Leaderboards
-      security: []
       responses:
         "200":
           description: Available leaderboard seasons.
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimit-Limit"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimit-Remaining"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimit-Reset"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/Access-Control-Allow-Origin"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/LeaderboardSeasonsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
 components:
   schemas:
@@ -534,16 +838,21 @@ components:
         id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier for the authenticated user.
         email:
           type: string
           format: email
+          maxLength: 254
         name:
           type: string
+          maxLength: 80
+          pattern: "^.{1,80}$"
           nullable: true
         image:
           type: string
           format: uri
+          maxLength: 2048
           nullable: true
         emailVerified:
           type: boolean
@@ -551,10 +860,12 @@ components:
         createdAt:
           type: string
           format: date-time
+          maxLength: 30
           description: Timestamp for when the user record was created.
         updatedAt:
           type: string
           format: date-time
+          maxLength: 30
           description: Timestamp for the last update to the user record.
     AuthSessionData:
       type: object
@@ -563,21 +874,28 @@ components:
       properties:
         token:
           type: string
+          maxLength: 2048
+          pattern: "^\\S{1,2048}$"
           description: Opaque bearer token for authenticated write operations.
         expiresAt:
           type: string
           format: date-time
+          maxLength: 30
           description: Expiration timestamp for the session.
         id:
           type: string
+          maxLength: 64
+          pattern: "^[A-Za-z0-9_-]{1,64}$"
           description: Identifier for the issued session.
         createdAt:
           type: string
           format: date-time
+          maxLength: 30
           description: Timestamp for when the session was created.
         updatedAt:
           type: string
           format: date-time
+          maxLength: 30
           description: Timestamp for the last update to the session.
     AuthSession:
       type: object
@@ -598,14 +916,18 @@ components:
         email:
           type: string
           format: email
+          maxLength: 254
           description: Email address used for the account.
         password:
           type: string
           format: password
+          minLength: 8
+          maxLength: 128
           description: Password associated with the email account.
         callbackURL:
           type: string
           format: uri
+          maxLength: 2048
           description: Optional URL to redirect to after sign-in completes.
         rememberMe:
           type: boolean
@@ -622,10 +944,13 @@ components:
           description: Indicates whether the client should perform a redirect.
         token:
           type: string
+          maxLength: 2048
+          pattern: "^\\S{1,2048}$"
           description: Session token that can be exchanged for authenticated requests.
         url:
           type: string
           format: uri
+          maxLength: 2048
           nullable: true
           description: Redirect destination when `redirect` is true.
         user:
@@ -648,9 +973,12 @@ components:
         id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
         display_name:
           type: string
+          maxLength: 64
+          pattern: "^.{1,64}$"
         active:
           type: boolean
     PlayerCreate:
@@ -660,11 +988,15 @@ components:
       properties:
         display_name:
           type: string
+          maxLength: 64
+          pattern: "^.{1,64}$"
     PlayerUpdate:
       type: object
       properties:
         display_name:
           type: string
+          maxLength: 64
+          pattern: "^.{1,64}$"
         active:
           type: boolean
 
@@ -679,12 +1011,16 @@ components:
         id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
         created_at:
           type: string
           format: date-time
+          maxLength: 30
         participants:
           type: array
+          minItems: 2
+          maxItems: 8
           items:
             $ref: "#/components/schemas/Player"
         loser:
@@ -697,28 +1033,34 @@ components:
       properties:
         participant_ids:
           type: array
+          maxItems: 8
           items:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
           minItems: 2
         loser_id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
     RoundUpdate:
       type: object
       properties:
         participant_ids:
           type: array
+          maxItems: 8
           items:
             type: string
             format: uuid
+            maxLength: 36
             description: UUID v7, time-ordered identifier.
           minItems: 2
         loser_id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
 
     Fettmattis:
@@ -731,17 +1073,20 @@ components:
         id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
         player:
           $ref: "#/components/schemas/Player"
         round_id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
           nullable: true
         created_at:
           type: string
           format: date-time
+          maxLength: 30
     FettmattisCreate:
       type: object
       required:
@@ -750,10 +1095,12 @@ components:
         player_id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
         round_id:
           type: string
           format: uuid
+          maxLength: 36
           description: UUID v7, time-ordered identifier.
           nullable: true
 
@@ -770,13 +1117,25 @@ components:
           $ref: "#/components/schemas/Player"
         rank:
           type: integer
+          format: int32
+          minimum: 1
+          maximum: 10000
+          nullable: true
         loss_percentage:
           type: number
           format: float
+          minimum: 0
+          maximum: 1
         participation_count:
           type: integer
+          format: int32
+          minimum: 0
+          maximum: 100000
         loss_count:
           type: integer
+          format: int32
+          minimum: 0
+          maximum: 100000
     FettmattisLeaderboardItem:
       type: object
       required:
@@ -788,8 +1147,15 @@ components:
           $ref: "#/components/schemas/Player"
         rank:
           type: integer
+          format: int32
+          minimum: 1
+          maximum: 10000
+          nullable: true
         fettmattis_count:
           type: integer
+          format: int32
+          minimum: 0
+          maximum: 100000
 
     LeaderboardSeasonsResponse:
       type: object
@@ -799,8 +1165,12 @@ components:
         seasons:
           type: array
           description: Years with leaderboard data available.
+          maxItems: 100
           items:
             type: integer
+            format: int32
+            minimum: 1900
+            maximum: 2100
 
     Problem:
       type: object
@@ -813,48 +1183,169 @@ components:
         type:
           type: string
           format: uri
+          maxLength: 2048
           default: "about:blank"
         title:
           type: string
+          maxLength: 200
+          pattern: "^.{1,200}$"
         status:
           type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
         detail:
           type: string
+          maxLength: 2000
+          pattern: "^.{1,2000}$"
         instance:
           type: string
           format: uri
+          maxLength: 2048
 
   responses:
     BadRequest:
       description: The request body is invalid.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
       content:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
     Unauthorized:
       description: Authentication is required for this operation.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
       content:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
     NotFound:
       description: The requested resource was not found.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
       content:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
     Forbidden:
       description: The action is forbidden, e.g., editing an item outside the 24h window.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
       content:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
     Conflict:
       description: The resource already exists or the request conflicts with the current state.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
       content:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
+    TooManyRequests:
+      description: The client has sent too many requests in a given amount of time.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
+        Retry-After:
+          $ref: "#/components/headers/Retry-After"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/Problem"
+    InternalServerError:
+      description: The server encountered an unexpected error.
+      headers:
+        RateLimit-Limit:
+          $ref: "#/components/headers/RateLimit-Limit"
+        RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimit-Remaining"
+        RateLimit-Reset:
+          $ref: "#/components/headers/RateLimit-Reset"
+        Access-Control-Allow-Origin:
+          $ref: "#/components/headers/Access-Control-Allow-Origin"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/Problem"
+  headers:
+    Access-Control-Allow-Origin:
+      description: Allowed origin for cross-origin requests.
+      schema:
+        type: string
+        maxLength: 2048
+        pattern: "^\\S+$"
+    RateLimit-Limit:
+      description: The maximum number of requests permitted in the current window.
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 10000
+    RateLimit-Remaining:
+      description: The number of remaining requests in the current window.
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 10000
+    RateLimit-Reset:
+      description: Seconds remaining until the rate limit window resets.
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 86400
+    Retry-After:
+      description: Seconds to wait before making a new request.
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 86400
   securitySchemes:
     bearerAuth:
       type: http

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,8 +23,8 @@ info:
     **Error Handling**:
     - The API uses RFC 9457 for problem details in error responses.
   contact:
-    name: Mattis API Support
-    email: support@mattis.local
+    name: Kenneth Aasan
+    email: kenneth@aasan.dev
 servers:
   - url: /api
 tags:

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@electric-sql/pglite": "^0.3.10",
         "@playwright/test": "^1.47.2",
         "@stoplight/spectral-cli": "^6.15.0",
+        "@stoplight/spectral-owasp-ruleset": "^2.0.1",
         "@tailwindcss/postcss": "^4.1.14",
         "@testing-library/react": "^16.3.0",
         "@types/node": "^24.7.2",
@@ -3423,6 +3424,17 @@
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-owasp-ruleset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-owasp-ruleset/-/spectral-owasp-ruleset-2.0.1.tgz",
+      "integrity": "sha512-9S6Z3lMwIh5oe5X5xS867iQm8xYMgCwY08FiR4At6Ivu78lQ7okFS7+I9RUs01Zawd0PtageQeZ83Ety/vlJQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stoplight/spectral-formats": "^1.6.0",
+        "@stoplight/spectral-functions": "^1.7.2"
       }
     },
     "node_modules/@stoplight/spectral-parsers": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@electric-sql/pglite": "^0.3.10",
     "@playwright/test": "^1.47.2",
     "@stoplight/spectral-cli": "^6.15.0",
+    "@stoplight/spectral-owasp-ruleset": "^2.0.1",
     "@tailwindcss/postcss": "^4.1.14",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^24.7.2",

--- a/specs/001-build-an-application/data-model.md
+++ b/specs/001-build-an-application/data-model.md
@@ -10,7 +10,7 @@ This document defines the database schema for the Mattis Stats application. The 
 
 ```
 +-------------+       +--------------------+       +-------------------+
-|   Users     |       |      Players       |       | FettMattis |
+|   Users     |       |      Players       |       | Fettmattis |
 |-------------|       |--------------------|       |-------------------|
 | id (PK)     |----<--| id (PK)            |----<--| id (PK)           |
 | username    |       | display_name       |       | player_id (FK)    |
@@ -101,18 +101,18 @@ Identifies the single loser for a round. A separate table enforces the one-to-on
 
 #### `fettmattis`
 
-Stores records of FettMattis.
+Stores records of Fettmattis.
 
 | Column       | Type          | Constraints                           | Description                                  |
 | ------------ | ------------- | ------------------------------------- | -------------------------------------------- |
-| `id`         | `uuid (v7)`   | Primary Key                           | Unique identifier for the FettMattis record. |
-| `player_id`  | `uuid (v7)`   | Foreign Key -> `players.id`, Not Null | The player receiving the FettMattis.         |
+| `id`         | `uuid (v7)`   | Primary Key                           | Unique identifier for the Fettmattis record. |
+| `player_id`  | `uuid (v7)`   | Foreign Key -> `players.id`, Not Null | The player receiving the Fettmattis.         |
 | `round_id`   | `uuid (v7)`   | Foreign Key -> `rounds.id`, Nullable  | The round associated with the fettmattis.    |
 | `created_by` | `uuid (v7)`   | Foreign Key -> `users.id`, Not Null   | The user who gave the fettmattis.            |
-| `created_at` | `timestamptz` | Not Null, Default `now()`             | Timestamp of FettMattis creation.            |
+| `created_at` | `timestamptz` | Not Null, Default `now()`             | Timestamp of Fettmattis creation.            |
 | `revoked_at` | `timestamptz` | Nullable                              | Timestamp for soft deletion (revocation).    |
 
-**Constraint**: A unique index on `(player_id, round_id)` where `revoked_at IS NULL` will enforce that a player can only receive one FettMattis per round.
+**Constraint**: A unique index on `(player_id, round_id)` where `revoked_at IS NULL` will enforce that a player can only receive one Fettmattis per round.
 
 ### Derived Data
 

--- a/specs/001-build-an-application/plan.md
+++ b/specs/001-build-an-application/plan.md
@@ -27,7 +27,7 @@
 
 ## Summary
 
-This plan outlines the rewrite of the legacy Laravel-based "Mattis" stats application into a modern, serverless TypeScript application. The new system will track player participation, losses, and special "FettMattis records" using a dual-leaderboard model. The technical approach involves a Next.js frontend, a serverless backend using AWS Lambda and Aurora, and Infrastructure as Code managed by the AWS CDK.
+This plan outlines the rewrite of the legacy Laravel-based "Mattis" stats application into a modern, serverless TypeScript application. The new system will track player participation, losses, and special "Fettmattis records" using a dual-leaderboard model. The technical approach involves a Next.js frontend, a serverless backend using AWS Lambda and Aurora, and Infrastructure as Code managed by the AWS CDK.
 
 ## Technical Context
 
@@ -63,7 +63,7 @@ The following gates from Constitution v1.1.0 are satisfied:
     - UI surfaces (leaderboards, forms) are identified.
     - Requirements adhere to WCAG 2.2 AA, covering forms, semantic HTML, and keyboard navigation as per the spec.
 5.  **Observability Baseline**:
-    - Key events (e.g., `RoundCreate`, `FettMattisCreate`) and metrics are defined in the spec.
+    - Key events (e.g., `RoundCreate`, `FettmattisCreate`) and metrics are defined in the spec.
 6.  **Testing Gates Defined**:
     - The plan includes contract tests (OpenAPI), integration tests (user scenarios), and E2E tests (accessibility).
 7.  **Data / Privacy / Retention**: The spec defines indefinite retention for audit purposes and soft-delete behavior.

--- a/specs/001-build-an-application/quickstart.md
+++ b/specs/001-build-an-application/quickstart.md
@@ -99,6 +99,6 @@ To validate the acceptance criteria from the feature specification:
 
 1.  **Create Players**: Use the UI or send `POST` requests to `/api/players` with a `display_name`.
 2.  **Record a Round**: Send a `POST` request to `/api/rounds` with `participant_ids` and a `loser_id`.
-3.  **Grant a FettMattis**: Send a `POST` request to `/api/fettmattis` with a `player_id` and an optional `round_id`.
+3.  **Grant a Fettmattis**: Send a `POST` request to `/api/fettmattis` with a `player_id` and an optional `round_id`.
 4.  **View Leaderboards**: Access the leaderboard pages in the application to verify that stats are calculated and displayed correctly.
-5.  **Test 24h Window**: Record a round/FettMattis and attempt to edit/delete it immediately. Wait 24 hours (or manually adjust the `created_at` timestamp in the database for testing) and confirm the action is forbidden.
+5.  **Test 24h Window**: Record a round/Fettmattis and attempt to edit/delete it immediately. Wait 24 hours (or manually adjust the `created_at` timestamp in the database for testing) and confirm the action is forbidden.

--- a/specs/001-build-an-application/research.md
+++ b/specs/001-build-an-application/research.md
@@ -28,7 +28,7 @@ This document outlines the technology stack and architectural decisions for the 
   - **Database**: Amazon Aurora Serverless (PostgreSQL compatible) is a managed, auto-scaling relational database that aligns with the serverless model. It handles unpredictable workloads well and reduces operational overhead. Drizzle ORM will be used for database access as per the constitution.
 - **Alternatives Considered**:
   - **AWS EC2 / Fargate**: Requires more manual configuration and management compared to the serverless approach. Not aligned with the user's request.
-  - **DynamoDB**: A NoSQL option. While highly scalable, the relational nature of the data (Players, Rounds, FettMattis records) makes a SQL database like Aurora a more natural fit.
+  - **DynamoDB**: A NoSQL option. While highly scalable, the relational nature of the data (Players, Rounds, Fettmattis records) makes a SQL database like Aurora a more natural fit.
 
 ### 4. Infrastructure as Code (IaC)
 

--- a/specs/001-build-an-application/spec.md
+++ b/specs/001-build-an-application/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Rewrite Legacy Laravel Mattis Stats App to Modern TypeScript Application (Loss Model + FettMattis Model)
+# Feature Specification: Rewrite Legacy Laravel Mattis Stats App to Modern TypeScript Application (Loss Model + Fettmattis Model)
 
 **Feature Branch**: `001-build-an-application`  
 **Created**: 2025-10-05  
@@ -6,7 +6,7 @@
 **Status**: Draft – 14 resolved / 0 open clarifications (All listed clarifications resolved on 2025-10-05)
 
 **Input (original brief)**: "Rewrite the app in the `laravel` folder to TypeScript. The app tracks statistics for the card game 'Mattis'. Use legacy behavior & UI as reference."  
-**Current Direction Update**: Scoring/winner model removed. System now tracks: participation, a single loser per round, yearly loss percentage, and independent FettMattiss (manually fettmattised, optional round link). Two leaderboards: (1) Regular (lowest loss %), (2) Fettmattis (most fettmattiss). Year resets January 1st (UTC). 24h edit/soft‑delete window for rounds and fettmattiss.
+**Current Direction Update**: Scoring/winner model removed. System now tracks: participation, a single loser per round, yearly loss percentage, and independent Fettmattiss (manually fettmattised, optional round link). Two leaderboards: (1) Regular (lowest loss %), (2) Fettmattis (most fettmattiss). Year resets January 1st (UTC). 24h edit/soft‑delete window for rounds and fettmattiss.
 
 ---
 
@@ -38,18 +38,18 @@ As participants of the Mattis community, we want to record each round (who playe
 
 1. **Create Player**: Given a need to add a new participant, when a user supplies a unique display name, then the player appears in all selection lists and future statistics.
 2. **Record Round**: Given at least 2 participating players, when a round is saved with participants and one marked loser, then yearly stats and leaderboards reflect the change immediately.
-3. **FettMattis Fettmattis**: Given at least 1 existing player (and optionally a recently recorded round), when a user creates a FettMattis specifying a player (and optionally linking a round), then the Fettmattis leaderboard updates fettmattis counts immediately.
-4. **Revoke FettMattis (within 24h)**: Given an fettmattis is less than 24 hours old, when a user revokes it, then the fettmattis no longer contributes to any fettmattis metrics and an audit trail persists the change.
+3. **Fettmattis Fettmattis**: Given at least 1 existing player (and optionally a recently recorded round), when a user creates a Fettmattis specifying a player (and optionally linking a round), then the Fettmattis leaderboard updates fettmattis counts immediately.
+4. **Revoke Fettmattis (within 24h)**: Given an fettmattis is less than 24 hours old, when a user revokes it, then the fettmattis no longer contributes to any fettmattis metrics and an audit trail persists the change.
 5. **View Regular Leaderboard**: Given rounds exist this calendar year (UTC), when the leaderboard is viewed, then players with at least 1 participation this year are ranked by (a) loss percentage ascending (losses / total rounds in the calendar year), (b) participation count descending, (c) player name ascending.
-6. **View Fettmattis Leaderboard**: Given at least one non-revoked FettMattis exists this year, when the Fettmattis leaderboard is opened, then players are ranked by total fettmattiss descending, tie‑break by player name ascending.
+6. **View Fettmattis Leaderboard**: Given at least one non-revoked Fettmattis exists this year, when the Fettmattis leaderboard is opened, then players are ranked by total fettmattiss descending, tie‑break by player name ascending.
 7. **Year Reset**: Given a new calendar year has begun (UTC), when the first new round or fettmattis is recorded, then all per‑year statistics (loss percentage, participations, fettmattis counts) restart from zero without altering historical prior year data.
 8. **Edit Round (within 24h)**: Given a round was created less than 24 hours ago (UTC comparison), when an authorized user edits participants or changes the loser, then statistics recompute accordingly.
 9. **Soft Delete Round (within 24h)**: Given a round is under 24 hours old, when it is deleted, then it no longer contributes to any metrics and an audit trail is preserved (conceptual—stakeholders may review removed counts if governance needed).
 10. **Edit Attempt After Window**: Given a round is older than 24 hours, when a user attempts to edit or delete it, then the system blocks the action and explains the lock policy.
-11. **Revoke Attempt After Window**: Given a FettMattis is older than 24 hours, when a user attempts to revoke it, then the system blocks the action and explains the lock policy.
+11. **Revoke Attempt After Window**: Given a Fettmattis is older than 24 hours, when a user attempts to revoke it, then the system blocks the action and explains the lock policy.
 12. **Inactive Player Visibility**: Given a player was marked inactive but has participated in at least one round this year, when leaderboards are viewed, then the player remains visible (inactive does not hide current‑year participants).
 13. **Validation Failure (Round)**: Given a round submission missing a loser or with fewer than required participants, when submitted, then the system rejects it and associates accessible error messages to relevant inputs.
-14. **Validation Failure (FettMattis)**: Given an fettmattis submission missing a player or duplicating an existing (player + same round link) combination, when submitted, then the system rejects it with accessible error messages.
+14. **Validation Failure (Fettmattis)**: Given an fettmattis submission missing a player or duplicating an existing (player + same round link) combination, when submitted, then the system rejects it with accessible error messages.
 15. **Player Rename**: Given a player is renamed, when any leaderboard or detail page is viewed, then historical data remains intact while the new display name appears.
 16. **Empty State**: Given no rounds (or fettmattiss) exist this year, when leaderboards are viewed, then clear empty state messaging appears (no players ranked yet).
 17. **Time Zone Consistency**: Given a round or fettmattis near year boundary (e.g., Dec 31 23:59:30 UTC), when recorded, then it is counted in the correct year determined strictly by UTC.
@@ -58,9 +58,9 @@ As participants of the Mattis community, we want to record each round (who playe
 
 - Round with duplicate player entries → reject (no duplicates per round).
 - Multiple losers attempt → reject (single loser enforced).
-- Duplicate FettMattis for same player + same round link → reject.
-- FettMattis referencing a soft-deleted round → reject (round linkage must target active round) OR allow omission of round link (user must re‑fettmattis without linkage) (ABUSE-CLAR-01 may refine; currently reject).
-- Attempt to create an FettMattis then revoke after window (>24h) → block with message.
+- Duplicate Fettmattis for same player + same round link → reject.
+- Fettmattis referencing a soft-deleted round → reject (round linkage must target active round) OR allow omission of round link (user must re‑fettmattis without linkage) (ABUSE-CLAR-01 may refine; currently reject).
+- Attempt to create an Fettmattis then revoke after window (>24h) → block with message.
 - Rapid sequential fettmattiss for same player (potential abuse) → allowed for now (monitor; ABUSE-CLAR-01 placeholder).
 - Player deactivated mid‑year → remains in rankings if participated this year; cannot receive new fettmattiss if policy later restricts (FR-CLAR-03 may extend this).
 - Rapid sequential round submissions near year boundary → ensure correct year attribution.
@@ -79,9 +79,9 @@ As participants of the Mattis community, we want to record each round (who playe
 - **FR-004**: System MUST allow editing a Round’s participants and loser ONLY within 24h of creation (UTC) then lock further edits.
 - **FR-005**: System MUST soft delete a Round within 24h of creation and disallow deletion afterward; soft deleted rounds MUST be excluded from all statistics.
 - **FR-006**: System MUST compute yearly (UTC) statistics for each player: total participations, total losses, loss percentage = losses / total rounds in the calendar year (denominator = total rounds in year; intentional fairness model).
-- **FR-007 (Revised)**: System MUST compute yearly FettMattis count per player (non-revoked fettmattiss), and total global fettmattis count.
+- **FR-007 (Revised)**: System MUST compute yearly Fettmattis count per player (non-revoked fettmattiss), and total global fettmattis count.
 - **FR-008**: System MUST present the Regular Leaderboard with ranking & tie-break logic: primary loss % ascending, secondary participation count descending, tertiary player name ascending.
-- **FR-009 (Revised)**: System MUST present the Fettmattis Leaderboard ranking players by total non-revoked FettMattiss descending, tie-break player name ascending.
+- **FR-009 (Revised)**: System MUST present the Fettmattis Leaderboard ranking players by total non-revoked Fettmattiss descending, tie-break player name ascending.
 - **FR-010**: System MUST reset yearly statistics automatically on January 1st 00:00:00 UTC without modifying persisted historical records.
 - **FR-011**: System MUST ensure player rename propagates to all displays without altering historical participation/loss/fettmattis data.
 - **FR-012**: System MUST expose a player detail view including: yearly metrics, historical trend (optional if clarified), total fettmattiss, and loss percentage trend if stored.
@@ -96,9 +96,9 @@ As participants of the Mattis community, we want to record each round (who playe
 - **FR-021**: System MUST base all time calculations and window enforcement on UTC (no local offset reliance).
 - **FR-022**: System SHOULD provide an overview page summarizing: players (active/total), total rounds this year, total fettmattiss this year, average participants per round.
 - **FR-023**: System SHOULD surface a warning if inactivity (0 participations) results in top loss % placement (potential fairness communication) (pending stakeholder approval FR-CLAR-06).
-- **FR-024 (New)**: System MUST allow creating a FettMattis with: (a) target player (b) optional round reference (nullable) (c) created timestamp (d) created_by actor.
-- **FR-025 (New)**: System MUST allow revoking (soft deleting) a FettMattis within 24h of creation; after 24h fettmattis becomes immutable.
-- **FR-026 (New)**: System MUST enforce uniqueness: no more than one active (non-revoked) FettMattis for the same (player, round) pair (if round link supplied); multiple fettmattiss without round linkage allowed unless limited by ABUSE-CLAR-01 future rule.
+- **FR-024 (New)**: System MUST allow creating a Fettmattis with: (a) target player (b) optional round reference (nullable) (c) created timestamp (d) created_by actor.
+- **FR-025 (New)**: System MUST allow revoking (soft deleting) a Fettmattis within 24h of creation; after 24h fettmattis becomes immutable.
+- **FR-026 (New)**: System MUST enforce uniqueness: no more than one active (non-revoked) Fettmattis for the same (player, round) pair (if round link supplied); multiple fettmattiss without round linkage allowed unless limited by ABUSE-CLAR-01 future rule.
 - **FR-027 (New)**: System MUST maintain an audit trail for fettmattis creation and revocation (timestamps, actor, prior state, optional rationale if later added).
 
 ### Clarification Placeholders (Unresolved — require stakeholder input)
@@ -122,9 +122,9 @@ _See Resolved Clarifications section for FR-CLAR-01 & FR-CLAR-02 decisions._
 
 ### Key Entities
 
-- **Player**: display name (unique), active flag, created date. Relationships: Participates in many Rounds; may receive many FettMattiss.
+- **Player**: display name (unique), active flag, created date. Relationships: Participates in many Rounds; may receive many Fettmattiss.
 - **Round**: created timestamp (UTC), participants (Players), single loser (Player), deleted*at (nullable for soft delete). \_No fettround flag stored.*
-- **FettmattisFettMattis**: id, player_id (required), round_id (optional, nullable), created_at (UTC), revoked_at (nullable), created_by actor id. Represents a discrete recognition; counts only if not revoked.
+- **FettmattisFettmattis**: id, player_id (required), round_id (optional, nullable), created_at (UTC), revoked_at (nullable), created_by actor id. Represents a discrete recognition; counts only if not revoked.
 - **Yearly Statistics (Derived, not persisted unless cached)**: For each calendar year (UTC): participations, losses, loss %, fettmattis count.
 - **User (Actor)**: Person performing actions. Decision: `User` (auth) is separate from `Player` (profile); `created_by` and audit fields reference `user.id`. Players may optionally link to a `user_id` for auth/profile pairing.
 
@@ -150,7 +150,7 @@ _See Resolved Clarifications section for FR-CLAR-01 & FR-CLAR-02 decisions._
 
 ### Observability
 
-- Events: PlayerCreated, PlayerDeactivated, RoundRecorded, RoundEdited, RoundSoftDeleted, FettMattisCreated, FettMattisRevoked, YearStatsViewed, LeaderboardViewed.
+- Events: PlayerCreated, PlayerDeactivated, RoundRecorded, RoundEdited, RoundSoftDeleted, FettmattisCreated, FettmattisRevoked, YearStatsViewed, LeaderboardViewed.
 - Counters/Gauges: totalPlayers, activePlayers, roundsYearToDate, fettmattissYearToDate, avgParticipantsPerRoundYTD.
 - Derived Metrics (Leaderboards): lossPercentage, participationRank, fettmattisRank.
 - Error Events: ValidationFailed(round), ValidationFailed(fettmattis), EditWindowExpired(round/fettmattis), NotFound(player/round/fettmattis), DuplicatePlayerName.
@@ -195,12 +195,12 @@ _See Resolved Clarifications section for FR-CLAR-01 & FR-CLAR-02 decisions._
 | totalPlayers               | Counter              | Total players ever created                            | Player records                          |
 | activePlayers              | Gauge                | Current active players                                | Player.active                           |
 | roundsYearToDate           | Counter              | Non-deleted rounds in current UTC year                | Round.created_at + deleted_at null      |
-| fettmattissYearToDate      | Counter              | Non-revoked fettmattiss in current UTC year           | FettMattis.created_at + revoked_at null |
+| fettmattissYearToDate      | Counter              | Non-revoked fettmattiss in current UTC year           | Fettmattis.created_at + revoked_at null |
 | avgParticipantsPerRoundYTD | Gauge                | Mean participants per non-deleted round (year)        | Derived                                 |
 | losses                     | Counter (per player) | Times player designated loser this year               | Round.loser_id                          |
 | participations             | Counter (per player) | Rounds player joined this year                        | Round participants                      |
 | lossPercentage             | Gauge (per player)   | losses / total rounds in year                         | Derived                                 |
-| playerFettMattiss          | Counter (per player) | FettMattiss granted to player this year (non-revoked) | FettMattis.player_id                    |
+| playerFettmattiss          | Counter (per player) | Fettmattiss granted to player this year (non-revoked) | Fettmattis.player_id                    |
 
 ---
 
@@ -245,7 +245,7 @@ _See Resolved Clarifications section for FR-CLAR-01 & FR-CLAR-02 decisions._
 | ID              | Decision                                                                                                                                              | Rationale                                                                                                                                                      | Date       | Impacted Requirements                                                            |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------- |
 | FR-CLAR-01      | Minimum participants per round is 2; codified via FR-003 & FR-014(d).                                                                                 | Ensures statistical relevance; legacy usage never <2 players; avoids degenerate single-player "round" inflating denominators.                                  | 2025-10-05 | FR-003, FR-014                                                                   |
-| FR-CLAR-02      | Adopt standalone manual FettMattis (optional round link). No automatic derivation rule in MVP. No justification text field yet.                       | Maximizes flexibility with low implementation cost; defers complexity & abuse controls; preserves ability to later add thresholds/caps without data migration. | 2025-10-05 | FR-007 (revised), FR-009 (revised), FR-024–FR-027, Metrics Catalog, Key Entities |
+| FR-CLAR-02      | Adopt standalone manual Fettmattis (optional round link). No automatic derivation rule in MVP. No justification text field yet.                       | Maximizes flexibility with low implementation cost; defers complexity & abuse controls; preserves ability to later add thresholds/caps without data migration. | 2025-10-05 | FR-007 (revised), FR-009 (revised), FR-024–FR-027, Metrics Catalog, Key Entities |
 | ABUSE-CLAR-01   | Defer hard caps initially; implement monitoring and alerting. Add rate-limit primitives to be applied later if abuse observed.                        | Low initial friction for community while ensuring observability; enables data‑driven cap policy later.                                                         | 2025-10-05 | FR-026, Security & Observability, Tasks (monitoring)                             |
 | SEC-CLAR-01     | Phase 1: Anonymous reads, authenticated writes (basic actor model). Stronger auth (OIDC/roles) planned as follow-up.                                  | Balances quick MVP delivery with write accountability; allows later migration to federated auth (OIDC).                                                        | 2025-10-05 | Security & Supply Chain, FR-024–FR-027, Key Entities (User/Actor)                |
 | SEC-CLAR-02     | Require rate limiting for write paths (round creation & fettmattiss) with user-id based keys and IP fallback; captcha deferred unless abuse observed. | Prevents automated mass writes while keeping UX friction low; ties into ABUSE monitoring.                                                                      | 2025-10-05 | FR-003, FR-024, Performance & Security sections                                  |

--- a/specs/001-build-an-application/tasks.md
+++ b/specs/001-build-an-application/tasks.md
@@ -43,7 +43,7 @@
 
 - [x] **T027**: [P] Create a reusable `PlayerForm` component for creating and editing players.
 - [x] **T028**: [P] Create a `RoundForm` component for recording and editing rounds.
-- [x] **T029**: [P] Create a `FettMattisForm` component for creating FettMattis records.
+- [x] **T029**: [P] Create a `FettmattisForm` component for creating Fettmattis records.
 - [x] **T030**: [P] Develop the main `Leaderboard` component to display both regular and Fettmattis leaderboards.
 - [x] **T031**: Implement the player management page.
 - [x] **T032**: Implement the round creation/editing page.

--- a/specs/001-build-an-application/validation.md
+++ b/specs/001-build-an-application/validation.md
@@ -12,10 +12,10 @@ The script exercises the API directly, following the acceptance criteria in `qui
 | ----------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | Create Player                 | ✓ PASS | `POST /api/players` returned `201`, and subsequent `GET /api/players` showed the newly created records.                        |
 | Record Round                  | ✓ PASS | `POST /api/rounds` (with two participants) succeeded and an immediate `PUT` within the 24h window returned `200`.              |
-| FettMattis Grant/Revoke       | ✓ PASS | `POST /api/fettmattis` returned `201`, regular leaderboard reflected the award, and an immediate `DELETE` responded `204`.     |
+| Fettmattis Grant/Revoke       | ✓ PASS | `POST /api/fettmattis` returned `201`, regular leaderboard reflected the award, and an immediate `DELETE` responded `204`.     |
 | View Regular Leaderboard      | ✓ PASS | `GET /api/leaderboard/regular?year=2025` returned entries with correct participation/loss counts for both test players.        |
-| View FettMattis Leaderboard   | ✓ PASS | `GET /api/leaderboard/fettmattis?year=2025` showed the active FettMattis counts.                                               |
+| View Fettmattis Leaderboard   | ✓ PASS | `GET /api/leaderboard/fettmattis?year=2025` showed the active Fettmattis counts.                                               |
 | 24h Edit/Delete Lock (Rounds) | ✓ PASS | After shifting `created_at` back 26 hours, `PUT /api/rounds/{id}` and `DELETE /api/rounds/{id}` both returned `403 Forbidden`. |
-| 24h Revoke Lock (FettMattis)  | ✓ PASS | After shifting `created_at` back 26 hours, `DELETE /api/fettmattis/{id}` returned `403 Forbidden`.                             |
+| 24h Revoke Lock (Fettmattis)  | ✓ PASS | After shifting `created_at` back 26 hours, `DELETE /api/fettmattis/{id}` returned `403 Forbidden`.                             |
 
 All acceptance validations now pass; task **T040** is complete.

--- a/spectral/owasp-api-governance/.spectral.yaml
+++ b/spectral/owasp-api-governance/.spectral.yaml
@@ -1,0 +1,6 @@
+extends:
+  - spectral:oas
+  - ./governance-rules/governance-rules.yaml
+
+formats:
+  - oas3

--- a/spectral/owasp-api-governance/governance-rules/governance-rules.yaml
+++ b/spectral/owasp-api-governance/governance-rules/governance-rules.yaml
@@ -1,0 +1,16 @@
+rules:
+  info-contact-required:
+    description: "Info object must include a contact field."
+    severity: error
+    given: "$.info"
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required:
+            - contact
+          properties:
+            contact:
+              type: object
+              minProperties: 1

--- a/src/app/__tests__/client-pages.test.tsx
+++ b/src/app/__tests__/client-pages.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import PlayersClientPage from "@/app/players/players-client";
 import RoundsClientPage from "@/app/rounds/rounds-client";
 import type { Player } from "@/lib/api/players-client";
-import type { FettMattis, Round } from "@/lib/api/schemas";
+import type { Fettmattis, Round } from "@/lib/api/schemas";
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: vi.fn(),
@@ -202,7 +202,7 @@ describe("RoundsClientPage", () => {
 
     const rounds: Round[] = [latestRound];
 
-    const fettmattis: FettMattis[] = [
+    const fettmattis: Fettmattis[] = [
       {
         id: "00000000-0000-4000-8000-000000000200",
         created_at: new Date().toISOString(),
@@ -231,7 +231,7 @@ describe("RoundsClientPage", () => {
       }
 
       if (Array.isArray(key) && key[0] === "fettmattis" && key[1] === "list") {
-        return createQueryResult<FettMattis[]>({
+        return createQueryResult<Fettmattis[]>({
           data: fettmattis,
           isLoading: false,
         });
@@ -299,7 +299,7 @@ describe("RoundsClientPage", () => {
         createQueryResult<Round[]>({ data: [], isLoading: false }),
       )
       .mockImplementationOnce(() =>
-        createQueryResult<FettMattis[]>({ data: [], isLoading: false }),
+        createQueryResult<Fettmattis[]>({ data: [], isLoading: false }),
       );
 
     mockMutationSequence([

--- a/src/app/__tests__/pages.test.tsx
+++ b/src/app/__tests__/pages.test.tsx
@@ -17,13 +17,13 @@ const {
   mockReplace,
   mockGetOverviewStats,
   mockListRecentRounds,
-  mockListRecentFettMattis,
+  mockListRecentFettmattis,
 } = vi.hoisted(() => ({
   mockUseAuth: vi.fn(),
   mockReplace: vi.fn(),
   mockGetOverviewStats: vi.fn(),
   mockListRecentRounds: vi.fn(),
-  mockListRecentFettMattis: vi.fn(),
+  mockListRecentFettmattis: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -57,7 +57,7 @@ vi.mock("@/components/Leaderboard", () => ({
 vi.mock("@/lib/db-client", () => ({
   getOverviewStats: mockGetOverviewStats,
   listRecentRounds: mockListRecentRounds,
-  listRecentFettMattis: mockListRecentFettMattis,
+  listRecentFettmattis: mockListRecentFettmattis,
 }));
 
 vi.mock("next/server", () => ({
@@ -162,7 +162,7 @@ describe("Home page", () => {
   test("renders highlights from overview stats", async () => {
     mockGetOverviewStats.mockResolvedValue({
       totalRounds: 12,
-      fettMattisMoments: 3,
+      fettmattisMoments: 3,
       activePlayers: 4,
     });
 
@@ -180,7 +180,7 @@ describe("Home page", () => {
       },
     ]);
 
-    mockListRecentFettMattis.mockResolvedValue([
+    mockListRecentFettmattis.mockResolvedValue([
       {
         id: "fm-1",
         player: { id: "p2", displayName: "Nils", active: true },

--- a/src/app/api/fettmattis/[fettmattisId]/__tests__/delete-fettmattis.test.ts
+++ b/src/app/api/fettmattis/[fettmattisId]/__tests__/delete-fettmattis.test.ts
@@ -7,14 +7,14 @@ const mocks = vi.hoisted(() => {
   class MockForbiddenError extends Error {}
 
   return {
-    revokeFettMattis: vi.fn(),
+    revokeFettmattis: vi.fn(),
     MockNotFoundError,
     MockForbiddenError,
   };
 });
 
 vi.mock("@/lib/db-client", () => ({
-  revokeFettMattis: mocks.revokeFettMattis,
+  revokeFettmattis: mocks.revokeFettmattis,
   NotFoundError: mocks.MockNotFoundError,
   ForbiddenError: mocks.MockForbiddenError,
 }));
@@ -30,11 +30,11 @@ const createMockRequest = () => {
 };
 
 beforeEach(() => {
-  mocks.revokeFettMattis.mockReset();
+  mocks.revokeFettmattis.mockReset();
 });
 
 test("T014: DELETE /api/fettmattis/{fettmattisId} should return 404 if the fettmattis does not exist", async () => {
-  mocks.revokeFettMattis.mockRejectedValueOnce(
+  mocks.revokeFettmattis.mockRejectedValueOnce(
     new mocks.MockNotFoundError("Fettmattis not found."),
   );
 
@@ -55,7 +55,7 @@ test("T014: DELETE /api/fettmattis/{fettmattisId} should return 404 if the fettm
 });
 
 test("T014: DELETE /api/fettmattis/{fettmattisId} should return 204 on success", async () => {
-  mocks.revokeFettMattis.mockResolvedValueOnce(undefined);
+  mocks.revokeFettmattis.mockResolvedValueOnce(undefined);
 
   const req = createMockRequest();
   const res = await DELETE(req, {
@@ -67,7 +67,7 @@ test("T014: DELETE /api/fettmattis/{fettmattisId} should return 204 on success",
   expect(res.status).toBe(204);
 
   // Ensure the database function was called with the correct data
-  expect(mocks.revokeFettMattis).toHaveBeenCalledWith(
+  expect(mocks.revokeFettmattis).toHaveBeenCalledWith(
     "00000000-0000-7000-0000-000000000005",
   );
 });

--- a/src/app/api/fettmattis/[fettmattisId]/route.ts
+++ b/src/app/api/fettmattis/[fettmattisId]/route.ts
@@ -5,7 +5,7 @@ import { requireAuthenticatedRequest } from "@/lib/auth/authorize";
 import {
   ForbiddenError,
   NotFoundError,
-  revokeFettMattis,
+  revokeFettmattis,
 } from "@/lib/db-client";
 
 export async function DELETE(
@@ -31,7 +31,7 @@ export async function DELETE(
   }
 
   try {
-    await revokeFettMattis(fettmattisId);
+    await revokeFettmattis(fettmattisId);
     return new Response(null, { status: 204 });
   } catch (error) {
     if (error instanceof NotFoundError) {

--- a/src/app/api/fettmattis/__tests__/post-fettmattis.test.ts
+++ b/src/app/api/fettmattis/__tests__/post-fettmattis.test.ts
@@ -7,14 +7,14 @@ const mocks = vi.hoisted(() => {
   class MockConflictError extends Error {}
 
   return {
-    createFettMattis: vi.fn(),
+    createFettmattis: vi.fn(),
     MockNotFoundError,
     MockConflictError,
   };
 });
 
 vi.mock("@/lib/db-client", () => ({
-  createFettMattis: mocks.createFettMattis,
+  createFettmattis: mocks.createFettmattis,
   NotFoundError: mocks.MockNotFoundError,
   ConflictError: mocks.MockConflictError,
 }));
@@ -29,7 +29,7 @@ const createRequest = (body: unknown) => {
 };
 
 beforeEach(() => {
-  mocks.createFettMattis.mockReset();
+  mocks.createFettmattis.mockReset();
 });
 
 test("T013: POST /api/fettmattis returns 201 with the created record", async () => {
@@ -43,7 +43,7 @@ test("T013: POST /api/fettmattis returns 201 with the created record", async () 
     createdAt: new Date("2025-01-01T00:00:00.000Z"),
   };
 
-  mocks.createFettMattis.mockResolvedValueOnce(record);
+  mocks.createFettmattis.mockResolvedValueOnce(record);
 
   const request = createRequest({
     player_id: record.player.id,
@@ -62,7 +62,7 @@ test("T013: POST /api/fettmattis returns 201 with the created record", async () 
     },
     created_at: record.createdAt.toISOString(),
   });
-  expect(mocks.createFettMattis).toHaveBeenCalledWith({
+  expect(mocks.createFettmattis).toHaveBeenCalledWith({
     playerId: record.player.id,
     createdBy: process.env.BASIC_AUTH_USER_ID,
   });
@@ -83,11 +83,11 @@ test("T013: POST /api/fettmattis returns 400 when validation fails", async () =>
   expect(() => ProblemDetailsSchema.parse(payload)).not.toThrow();
   expect(payload.title).toBe("Bad Request");
   expect(payload.detail).toBe("Must be a valid UUID.");
-  expect(mocks.createFettMattis).not.toHaveBeenCalled();
+  expect(mocks.createFettmattis).not.toHaveBeenCalled();
 });
 
 test("T013: POST /api/fettmattis returns 404 when the player or round is missing", async () => {
-  mocks.createFettMattis.mockRejectedValueOnce(
+  mocks.createFettmattis.mockRejectedValueOnce(
     new mocks.MockNotFoundError("Missing player"),
   );
 
@@ -103,7 +103,7 @@ test("T013: POST /api/fettmattis returns 404 when the player or round is missing
 });
 
 test("T013: POST /api/fettmattis returns 409 when a duplicate is detected", async () => {
-  mocks.createFettMattis.mockRejectedValueOnce(
+  mocks.createFettmattis.mockRejectedValueOnce(
     new mocks.MockConflictError("Duplicate"),
   );
 

--- a/src/app/api/fettmattis/route.ts
+++ b/src/app/api/fettmattis/route.ts
@@ -1,13 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
-import { toFettMattisResponse } from "@/lib/api/response-helpers";
-import { FettMattisCreateSchema, ListQuerySchema } from "@/lib/api/schemas";
+import { toFettmattisResponse } from "@/lib/api/response-helpers";
+import { FettmattisCreateSchema, ListQuerySchema } from "@/lib/api/schemas";
 import { requireAuthenticatedRequest } from "@/lib/auth/authorize";
 import {
   ConflictError,
-  createFettMattis,
-  listRecentFettMattis,
+  createFettmattis,
+  listRecentFettmattis,
   NotFoundError,
 } from "@/lib/db-client";
 import {
@@ -34,15 +34,15 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const fettMattisList = await listRecentFettMattis({
+    const fettmattisList = await listRecentFettmattis({
       limit: validation.data.limit,
     });
     logger.info("Returning fettmattis", {
       ...requestContext,
-      count: fettMattisList.length,
+      count: fettmattisList.length,
       limit: validation.data.limit,
     });
-    return NextResponse.json(fettMattisList.map(toFettMattisResponse));
+    return NextResponse.json(fettmattisList.map(toFettmattisResponse));
   } catch (error) {
     if (error instanceof ConflictError) {
       logger.warn("Conflict while listing fettmattis", {
@@ -100,7 +100,7 @@ export async function POST(req: NextRequest) {
       return badRequest("Malformed JSON in request body.");
     }
 
-    const validatedData = FettMattisCreateSchema.safeParse(body);
+    const validatedData = FettmattisCreateSchema.safeParse(body);
 
     if (!validatedData.success) {
       const detail =
@@ -116,19 +116,19 @@ export async function POST(req: NextRequest) {
 
     ({ player_id: playerId } = validatedData.data);
 
-    const newFettmattis = await createFettMattis({
+    const newFettmattis = await createFettmattis({
       playerId,
       createdBy: auth.user.id,
     });
 
     logger.info("Fettmattis created", {
       ...requestContext,
-      fettMattisId: newFettmattis.id,
+      fettmattisId: newFettmattis.id,
       userId: auth.user.id,
       playerId,
     });
 
-    return NextResponse.json(toFettMattisResponse(newFettmattis), {
+    return NextResponse.json(toFettmattisResponse(newFettmattis), {
       status: 201,
     });
   } catch (error) {

--- a/src/app/api/leaderboard/fettmattis/route.ts
+++ b/src/app/api/leaderboard/fettmattis/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { badRequest, createProblemResponse } from "@/lib/api/problem-details";
 import { LeaderboardQuerySchema } from "@/lib/api/schemas";
-import { getFettMattisLeaderboard } from "@/lib/db-client";
+import { getFettmattisLeaderboard } from "@/lib/db-client";
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
@@ -21,8 +21,8 @@ export async function GET(req: Request) {
   const year = requestedYear === "all" ? null : (requestedYear ?? fallbackYear);
 
   try {
-    const leaderboard = await getFettMattisLeaderboard(year);
-    return NextResponse.json(leaderboard.map(toFettMattisResponse));
+    const leaderboard = await getFettmattisLeaderboard(year);
+    return NextResponse.json(leaderboard.map(toFettmattisResponse));
   } catch (error) {
     return createProblemResponse({
       status: 500,
@@ -32,14 +32,14 @@ export async function GET(req: Request) {
   }
 }
 
-function toFettMattisResponse(entry: {
+function toFettmattisResponse(entry: {
   rank: number;
-  fettMattisCount: number;
+  fettmattisCount: number;
   player: { id: string; displayName: string; active: boolean };
 }) {
   return {
     rank: entry.rank,
-    fettmattis_count: entry.fettMattisCount,
+    fettmattis_count: entry.fettmattisCount,
     player: {
       id: entry.player.id,
       display_name: entry.player.displayName,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,12 +15,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
-  toFettMattisResponse,
+  toFettmattisResponse,
   toRoundResponse,
 } from "@/lib/api/response-helpers";
 import {
   getOverviewStats,
-  listRecentFettMattis,
+  listRecentFettmattis,
   listRecentRounds,
 } from "@/lib/db-client";
 
@@ -66,15 +66,15 @@ const workflowCards = [
 export default async function Home() {
   await connection();
 
-  const [overviewStats, recentRounds, recentFettMattis] = await Promise.all([
+  const [overviewStats, recentRounds, recentFettmattis] = await Promise.all([
     getOverviewStats(),
     listRecentRounds({ limit: 5 }),
-    listRecentFettMattis({ limit: 5 }),
+    listRecentFettmattis({ limit: 5 }),
   ]);
 
-  const { totalRounds, fettMattisMoments, activePlayers } = overviewStats;
+  const { totalRounds, fettmattisMoments, activePlayers } = overviewStats;
   const roundsForDisplay = recentRounds.map(toRoundResponse);
-  const fettMattisForDisplay = recentFettMattis.map(toFettMattisResponse);
+  const fettmattisForDisplay = recentFettmattis.map(toFettmattisResponse);
   const formatter = new Intl.NumberFormat("nb-NO");
 
   const highlightStats = [
@@ -85,7 +85,7 @@ export default async function Home() {
     },
     {
       label: "Fettmattis-øyeblikk",
-      value: formatter.format(fettMattisMoments),
+      value: formatter.format(fettmattisMoments),
       description: "Feirede utmerkelser du kan finne igjen.",
     },
     {
@@ -148,7 +148,7 @@ export default async function Home() {
                 </Button>
               </CardHeader>
               <CardContent className="p-4 pt-2 sm:p-6 sm:pt-4">
-                <FettmattisTable fettMattis={fettMattisForDisplay} />
+                <FettmattisTable fettmattis={fettmattisForDisplay} />
               </CardContent>
             </Card>
           </div>

--- a/src/app/rounds/rounds-client.tsx
+++ b/src/app/rounds/rounds-client.tsx
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarCheck, Trophy } from "lucide-react";
 import { useMemo, useState } from "react";
-import { FettMattisForm } from "@/components/FettMattisForm";
+import { FettmattisForm } from "@/components/FettmattisForm";
 import { FettmattisTable } from "@/components/fettmattis-table";
 import { PageShell } from "@/components/layout/page-shell";
 import { RoundForm } from "@/components/RoundForm";
@@ -19,11 +19,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
-  createFettMattis,
-  createFettMattisListQueryKey,
-  type FettMattis,
-  fetchFettMattis,
-  revokeFettMattis,
+  createFettmattis,
+  createFettmattisListQueryKey,
+  type Fettmattis,
+  fetchFettmattis,
+  revokeFettmattis,
 } from "@/lib/api/fettmattis-client";
 import {
   fetchPlayers,
@@ -39,7 +39,7 @@ import {
   LATEST_ROUND_QUERY_KEY,
   type Round,
 } from "@/lib/api/rounds-client";
-import type { FettMattisCreate, RoundCreate } from "@/lib/api/schemas";
+import type { FettmattisCreate, RoundCreate } from "@/lib/api/schemas";
 
 const ROUND_FORM_SKELETON_KEYS = [
   "round-skeleton-1",
@@ -77,7 +77,7 @@ export default function RoundsClientPage() {
   });
 
   const roundsListQueryKey = createRoundsListQueryKey(ROUNDS_LIST_LIMIT);
-  const fettMattisListQueryKey = createFettMattisListQueryKey(
+  const fettmattisListQueryKey = createFettmattisListQueryKey(
     FETTMATTIS_LIST_LIMIT,
   );
 
@@ -86,17 +86,17 @@ export default function RoundsClientPage() {
     queryFn: () => fetchRounds({ limit: ROUNDS_LIST_LIMIT }),
   });
 
-  const fettMattisQuery = useQuery<FettMattis[], Error>({
-    queryKey: fettMattisListQueryKey,
-    queryFn: () => fetchFettMattis({ limit: FETTMATTIS_LIST_LIMIT }),
+  const fettmattisQuery = useQuery<Fettmattis[], Error>({
+    queryKey: fettmattisListQueryKey,
+    queryFn: () => fetchFettmattis({ limit: FETTMATTIS_LIST_LIMIT }),
   });
 
   const rounds = roundsQuery.data ?? [];
-  const fettMattisEntries = fettMattisQuery.data ?? [];
+  const fettmattisEntries = fettmattisQuery.data ?? [];
   const isRoundsLoading = roundsQuery.isLoading;
   const isRoundsFetching = roundsQuery.isFetching;
-  const isFettMattisLoading = fettMattisQuery.isLoading;
-  const isFettMattisFetching = fettMattisQuery.isFetching;
+  const isFettmattisLoading = fettmattisQuery.isLoading;
+  const isFettmattisFetching = fettmattisQuery.isFetching;
 
   const activePlayers = useMemo(
     () => players.filter((player) => player.active),
@@ -162,13 +162,13 @@ export default function RoundsClientPage() {
     },
   });
 
-  const fettMattisMutation = useMutation<void, Error, FettMattisCreate>({
-    mutationFn: createFettMattis,
+  const fettmattisMutation = useMutation<void, Error, FettmattisCreate>({
+    mutationFn: createFettmattis,
     onSuccess: () => {
       setStatus("Fettmattis tildelt. Klar for feiring!");
       setError(null);
       void queryClient.invalidateQueries({
-        queryKey: fettMattisListQueryKey,
+        queryKey: fettmattisListQueryKey,
       });
       void queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
     },
@@ -182,8 +182,8 @@ export default function RoundsClientPage() {
     await roundMutation.mutateAsync(data);
   };
 
-  const handleFettMattisSubmit = async (data: FettMattisCreate) => {
-    await fettMattisMutation.mutateAsync(data);
+  const handleFettmattisSubmit = async (data: FettmattisCreate) => {
+    await fettmattisMutation.mutateAsync(data);
   };
 
   const deleteRoundMutation = useMutation<void, Error, string>({
@@ -203,12 +203,12 @@ export default function RoundsClientPage() {
     },
   });
 
-  const revokeFettMattisMutation = useMutation<void, Error, string>({
-    mutationFn: async (fettMattisId) => revokeFettMattis(fettMattisId),
+  const revokeFettmattisMutation = useMutation<void, Error, string>({
+    mutationFn: async (fettmattisId) => revokeFettmattis(fettmattisId),
     onSuccess: () => {
       setStatus("Fettmattis fjernet. Oversikten er oppdatert.");
       setError(null);
-      void queryClient.invalidateQueries({ queryKey: fettMattisListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: fettmattisListQueryKey });
       void queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
     },
     onError: (mutationError) => {
@@ -221,8 +221,8 @@ export default function RoundsClientPage() {
     await deleteRoundMutation.mutateAsync(roundId);
   };
 
-  const handleFettMattisDelete = async (fettMattisId: string) => {
-    await revokeFettMattisMutation.mutateAsync(fettMattisId);
+  const handleFettmattisDelete = async (fettmattisId: string) => {
+    await revokeFettmattisMutation.mutateAsync(fettmattisId);
   };
 
   const deletingRoundIds =
@@ -230,9 +230,9 @@ export default function RoundsClientPage() {
       ? new Set([deleteRoundMutation.variables])
       : undefined;
 
-  const deletingFettMattisIds =
-    revokeFettMattisMutation.isPending && revokeFettMattisMutation.variables
-      ? new Set([revokeFettMattisMutation.variables])
+  const deletingFettmattisIds =
+    revokeFettmattisMutation.isPending && revokeFettmattisMutation.variables
+      ? new Set([revokeFettmattisMutation.variables])
       : undefined;
 
   return (
@@ -307,8 +307,8 @@ export default function RoundsClientPage() {
                 ))}
               </div>
             ) : (
-              <FettMattisForm
-                onSubmit={handleFettMattisSubmit}
+              <FettmattisForm
+                onSubmit={handleFettmattisSubmit}
                 players={hydratablePlayers}
                 rounds={[]}
               />
@@ -368,22 +368,22 @@ export default function RoundsClientPage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => void fettMattisQuery.refetch()}
-              disabled={isFettMattisFetching}
+              onClick={() => void fettmattisQuery.refetch()}
+              disabled={isFettmattisFetching}
             >
               Oppdater
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
             <FettmattisTable
-              fettMattis={fettMattisEntries}
-              isLoading={isFettMattisLoading}
-              onDelete={handleFettMattisDelete}
-              deletingIds={deletingFettMattisIds}
+              fettmattis={fettmattisEntries}
+              isLoading={isFettmattisLoading}
+              onDelete={handleFettmattisDelete}
+              deletingIds={deletingFettmattisIds}
             />
-            {fettMattisQuery.error ? (
+            {fettmattisQuery.error ? (
               <p className="text-destructive text-sm">
-                {fettMattisQuery.error.message}
+                {fettmattisQuery.error.message}
               </p>
             ) : null}
           </CardContent>

--- a/src/components/FettmattisForm.tsx
+++ b/src/components/FettmattisForm.tsx
@@ -5,8 +5,8 @@ import { useEffect, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
-  type FettMattisCreate,
-  FettMattisCreateSchema,
+  type FettmattisCreate,
+  FettmattisCreateSchema,
 } from "@/lib/api/schemas";
 
 interface SimplePlayer {
@@ -19,18 +19,18 @@ interface SimpleRound {
   readonly id: string;
 }
 
-interface FettMattisFormProps {
-  readonly onSubmit: (data: FettMattisCreate) => void | Promise<void>;
+interface FettmattisFormProps {
+  readonly onSubmit: (data: FettmattisCreate) => void | Promise<void>;
   readonly players: readonly SimplePlayer[];
   readonly rounds: readonly SimpleRound[];
-  readonly initialData?: FettMattisCreate;
+  readonly initialData?: FettmattisCreate;
 }
 
-export function FettMattisForm({
+export function FettmattisForm({
   onSubmit,
   players,
   initialData,
-}: FettMattisFormProps) {
+}: FettmattisFormProps) {
   const [playerId, setPlayerId] = useState(initialData?.player_id ?? "");
   const [roundId, setRoundId] = useState(initialData?.round_id ?? "");
   const [error, setError] = useState<string | null>(null);
@@ -55,12 +55,12 @@ export function FettMattisForm({
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const payload: FettMattisCreate = {
+    const payload: FettmattisCreate = {
       player_id: playerId,
       ...(roundId ? { round_id: roundId } : {}),
     };
 
-    const parsed = FettMattisCreateSchema.safeParse(payload);
+    const parsed = FettmattisCreateSchema.safeParse(payload);
     if (!parsed.success) {
       const firstIssue = parsed.error.issues.at(0);
       setError(firstIssue?.message ?? "Kunne ikke sende inn Fettmattis.");

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -232,7 +232,7 @@ export function Leaderboard() {
               <TableRow>
                 <TableHead className="w-16">Plass</TableHead>
                 <TableHead>Spiller</TableHead>
-                <TableHead className="text-right">FettMattis</TableHead>
+                <TableHead className="text-right">Fettmattis</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/src/components/__tests__/activity-tables.test.tsx
+++ b/src/components/__tests__/activity-tables.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { FettmattisTable } from "@/components/fettmattis-table";
 import { RoundsTable } from "@/components/rounds-table";
-import type { FettMattis } from "@/lib/api/fettmattis-client";
+import type { Fettmattis } from "@/lib/api/fettmattis-client";
 import type { Round } from "@/lib/api/schemas";
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
@@ -35,21 +35,21 @@ function createRound(overrides: Partial<Round> = {}): Round {
   } satisfies Round;
 }
 
-function createFettMattis(overrides: Partial<FettMattis> = {}): FettMattis {
+function createFettmattis(overrides: Partial<Fettmattis> = {}): Fettmattis {
   const player =
     overrides.player ??
     ({
       id: "fett-1",
       display_name: "Ada",
       active: true,
-    } as FettMattis["player"]);
+    } as Fettmattis["player"]);
 
   return {
     id: "fettmattis-1",
     created_at: new Date().toISOString(),
     player,
     ...overrides,
-  } satisfies FettMattis;
+  } satisfies Fettmattis;
 }
 
 describe("Activity tables", () => {
@@ -115,12 +115,12 @@ describe("Activity tables", () => {
     expect(screen.queryByRole("button", { name: "Slett" })).toBeNull();
   });
 
-  test("T193: FettMattis table exposes entry metadata when expanded", async () => {
-    const entry = createFettMattis({
+  test("T193: Fettmattis table exposes entry metadata when expanded", async () => {
+    const entry = createFettmattis({
       created_at: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
     });
 
-    render(<FettmattisTable fettMattis={[entry]} />);
+    render(<FettmattisTable fettmattis={[entry]} />);
 
     expect(screen.queryByText("Spillerstatus")).toBeNull();
 
@@ -136,24 +136,24 @@ describe("Activity tables", () => {
     expect(detailSection?.textContent).toContain("Endringsvindu");
   });
 
-  test("T193: FettMattis table restricts deletion after 24 hours", () => {
-    const staleEntry = createFettMattis({
+  test("T193: Fettmattis table restricts deletion after 24 hours", () => {
+    const staleEntry = createFettmattis({
       created_at: new Date(Date.now() - DAY_IN_MS * 3).toISOString(),
     });
 
     render(
       <FettmattisTable
-        fettMattis={[staleEntry]}
+        fettmattis={[staleEntry]}
         onDelete={vi.fn()}
-        emptyMessage="Ingen FettMattis"
+        emptyMessage="Ingen Fettmattis"
       />,
     );
 
     expect(screen.queryByRole("button", { name: "Slett" })).toBeNull();
   });
 
-  test("T193: FettMattis table surfaces delete button for recent entries", async () => {
-    const recentEntry = createFettMattis({
+  test("T193: Fettmattis table surfaces delete button for recent entries", async () => {
+    const recentEntry = createFettmattis({
       id: "recent-fettmattis",
       created_at: new Date().toISOString(),
     });
@@ -161,9 +161,9 @@ describe("Activity tables", () => {
 
     render(
       <FettmattisTable
-        fettMattis={[recentEntry]}
+        fettmattis={[recentEntry]}
         onDelete={onDelete}
-        emptyMessage="Ingen FettMattis"
+        emptyMessage="Ingen Fettmattis"
       />,
     );
 

--- a/src/components/__tests__/forms.test.tsx
+++ b/src/components/__tests__/forms.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { FettMattisForm } from "@/components/FettMattisForm";
+import { FettmattisForm } from "@/components/FettmattisForm";
 import { PlayerForm } from "@/components/PlayerForm";
 import { RoundForm } from "@/components/RoundForm";
 
@@ -111,12 +111,12 @@ describe("RoundForm", () => {
   });
 });
 
-describe("FettMattisForm", () => {
+describe("FettmattisForm", () => {
   test("submits selected player", async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <FettMattisForm onSubmit={onSubmit} players={PLAYERS} rounds={[]} />,
+      <FettmattisForm onSubmit={onSubmit} players={PLAYERS} rounds={[]} />,
     );
 
     const select = screen.getByLabelText("Spiller") as HTMLSelectElement;
@@ -130,7 +130,7 @@ describe("FettMattisForm", () => {
 
   test("resets invalid initial player selection", async () => {
     render(
-      <FettMattisForm
+      <FettmattisForm
         onSubmit={vi.fn()}
         players={PLAYERS}
         rounds={[]}

--- a/src/components/fettmattis-table.tsx
+++ b/src/components/fettmattis-table.tsx
@@ -12,7 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { FettMattis } from "@/lib/api/fettmattis-client";
+import type { Fettmattis } from "@/lib/api/fettmattis-client";
 
 const DATETIME_FORMATTER = new Intl.DateTimeFormat("nb-NO", {
   dateStyle: "medium",
@@ -32,21 +32,21 @@ const FETTMATTIS_TABLE_SKELETON_KEYS = [
 ] as const;
 
 interface FettmattisTableProps {
-  readonly fettMattis: FettMattis[];
+  readonly fettmattis: Fettmattis[];
   readonly className?: string;
   readonly isLoading?: boolean;
-  readonly onDelete?: (fettMattisId: string) => void | Promise<void>;
+  readonly onDelete?: (fettmattisId: string) => void | Promise<void>;
   readonly deletingIds?: ReadonlySet<string>;
   readonly emptyMessage?: string;
 }
 
 export function FettmattisTable({
-  fettMattis,
+  fettmattis,
   className,
   isLoading = false,
   onDelete,
   deletingIds,
-  emptyMessage = "Ingen FettMattis-utdelinger registrert ennå.",
+  emptyMessage = "Ingen Fettmattis-utdelinger registrert ennå.",
 }: FettmattisTableProps) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -74,7 +74,7 @@ export function FettmattisTable({
     ));
   };
 
-  const hasEntries = fettMattis.length > 0;
+  const hasEntries = fettmattis.length > 0;
 
   return (
     <Table className={className}>
@@ -88,7 +88,7 @@ export function FettmattisTable({
       <TableBody>
         {isLoading ? renderSkeletonRows() : null}
         {!isLoading && hasEntries
-          ? fettMattis.map((entry) => {
+          ? fettmattis.map((entry) => {
               const createdAt = new Date(entry.created_at);
               const formattedDate = DATETIME_FORMATTER.format(createdAt);
               const detailDate = DETAIL_DATETIME_FORMATTER.format(createdAt);

--- a/src/lib/__tests__/integration/db-client-crud.integration.test.ts
+++ b/src/lib/__tests__/integration/db-client-crud.integration.test.ts
@@ -12,9 +12,9 @@ const {
   listRecentRounds,
   updateRound,
   deleteRound,
-  createFettMattis,
-  listRecentFettMattis,
-  revokeFettMattis,
+  createFettmattis,
+  listRecentFettmattis,
+  revokeFettmattis,
   getLeaderboardSeasons,
   getOverviewStats,
   NotFoundError,
@@ -377,15 +377,15 @@ describe("Round CRUD operations", () => {
   });
 });
 
-describe("FettMattis CRUD operations", () => {
-  test("createFettMattis creates a new FettMattis record", async () => {
+describe("Fettmattis CRUD operations", () => {
+  test("createFettmattis creates a new Fettmattis record", async () => {
     const userId = process.env.BASIC_AUTH_USER_ID as string;
     const player = await createPlayer({
       id: generateId(),
       displayName: `FM-${generateId().slice(0, 8)}`,
     });
 
-    const fm = await createFettMattis({
+    const fm = await createFettmattis({
       playerId: player.id,
       createdBy: userId,
     });
@@ -395,44 +395,44 @@ describe("FettMattis CRUD operations", () => {
     expect(fm.revokedAt).toBeNull();
   });
 
-  test("createFettMattis throws NotFoundError for non-existent player", async () => {
+  test("createFettmattis throws NotFoundError for non-existent player", async () => {
     const userId = process.env.BASIC_AUTH_USER_ID as string;
 
     await expect(
-      createFettMattis({
+      createFettmattis({
         playerId: generateId(),
         createdBy: userId,
       }),
     ).rejects.toThrow(NotFoundError);
   });
 
-  test("listRecentFettMattis returns FettMattis records", async () => {
-    const records = await listRecentFettMattis({ limit: 5 });
+  test("listRecentFettmattis returns Fettmattis records", async () => {
+    const records = await listRecentFettmattis({ limit: 5 });
     expect(Array.isArray(records)).toBe(true);
   });
 
-  test("revokeFettMattis soft-revokes a FettMattis", async () => {
+  test("revokeFettmattis soft-revokes a Fettmattis", async () => {
     const userId = process.env.BASIC_AUTH_USER_ID as string;
     const player = await createPlayer({
       id: generateId(),
       displayName: `Revoke-${generateId().slice(0, 8)}`,
     });
 
-    const fm = await createFettMattis({
+    const fm = await createFettmattis({
       playerId: player.id,
       createdBy: userId,
     });
 
-    await revokeFettMattis(fm.id);
+    await revokeFettmattis(fm.id);
 
     // Verify it's no longer in the active list
-    const activeRecords = await listRecentFettMattis({ limit: 100 });
+    const activeRecords = await listRecentFettmattis({ limit: 100 });
     const found = activeRecords.find((r) => r.id === fm.id);
     expect(found).toBeUndefined();
   });
 
-  test("revokeFettMattis throws NotFoundError for non-existent FettMattis", async () => {
-    await expect(revokeFettMattis(generateId())).rejects.toThrow(NotFoundError);
+  test("revokeFettmattis throws NotFoundError for non-existent Fettmattis", async () => {
+    await expect(revokeFettmattis(generateId())).rejects.toThrow(NotFoundError);
   });
 });
 
@@ -448,10 +448,10 @@ describe("Leaderboard and Stats operations", () => {
     const stats = await getOverviewStats();
 
     expect(stats).toHaveProperty("totalRounds");
-    expect(stats).toHaveProperty("fettMattisMoments");
+    expect(stats).toHaveProperty("fettmattisMoments");
     expect(stats).toHaveProperty("activePlayers");
     expect(typeof stats.totalRounds).toBe("number");
-    expect(typeof stats.fettMattisMoments).toBe("number");
+    expect(typeof stats.fettmattisMoments).toBe("number");
     expect(typeof stats.activePlayers).toBe("number");
   });
 });

--- a/src/lib/__tests__/integration/round-leaderboard.integration.test.ts
+++ b/src/lib/__tests__/integration/round-leaderboard.integration.test.ts
@@ -1,18 +1,18 @@
 import { eq } from "drizzle-orm";
 import { expect, test } from "vitest";
 import { db } from "@/lib/db/db";
-import { fettmattis as fettMattisTable, rounds } from "@/lib/db/schema";
+import { fettmattis as fettmattisTable, rounds } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 
 const {
   createPlayer,
   createRound,
-  createFettMattis,
+  createFettmattis,
   getRegularLeaderboard,
-  getFettMattisLeaderboard,
+  getFettmattisLeaderboard,
 } = await import("@/lib/db-client");
 
-test("T016: recording a round updates the regular and FettMattis leaderboards", async () => {
+test("T016: recording a round updates the regular and Fettmattis leaderboards", async () => {
   const userId = process.env.BASIC_AUTH_USER_ID as never;
 
   const [ola, kari] = await Promise.all([
@@ -42,20 +42,20 @@ test("T016: recording a round updates the regular and FettMattis leaderboards", 
     lossCount: 0,
   });
 
-  await createFettMattis({
+  await createFettmattis({
     playerId: kari.id,
     createdBy: userId,
   });
 
-  const fettMattisLeaderboard = await getFettMattisLeaderboard(
+  const fettmattisLeaderboard = await getFettmattisLeaderboard(
     new Date().getFullYear(),
   );
 
-  expect(fettMattisLeaderboard).toHaveLength(1);
-  expect(fettMattisLeaderboard[0]).toMatchObject({
+  expect(fettmattisLeaderboard).toHaveLength(1);
+  expect(fettmattisLeaderboard[0]).toMatchObject({
     rank: 1,
     player: { displayName: "Kari" },
-    fettMattisCount: 1,
+    fettmattisCount: 1,
   });
 });
 
@@ -85,20 +85,20 @@ test("T068: all-time leaderboards aggregate results across seasons", async () =>
     .set({ createdAt: new Date(Date.UTC(previousYear, 5, 1, 12)) })
     .where(eq(rounds.id, pastRound.id));
 
-  await createFettMattis({
+  await createFettmattis({
     playerId: ada.id,
     createdBy: process.env.BASIC_AUTH_USER_ID as never,
   });
 
-  const historicalFettMattis = await createFettMattis({
+  const historicalFettmattis = await createFettmattis({
     playerId: ada.id,
     createdBy: process.env.BASIC_AUTH_USER_ID as never,
   });
 
   await db
-    .update(fettMattisTable)
+    .update(fettmattisTable)
     .set({ createdAt: new Date(Date.UTC(previousYear, 2, 14, 8)) })
-    .where(eq(fettMattisTable.id, historicalFettMattis.id));
+    .where(eq(fettmattisTable.id, historicalFettmattis.id));
 
   const currentRegularLeaderboard = await getRegularLeaderboard(currentYear);
 
@@ -144,32 +144,32 @@ test("T068: all-time leaderboards aggregate results across seasons", async () =>
   });
   expect(topAllTimeEntry.lossPercentage).toBeCloseTo(100);
 
-  const currentFettMattisLeaderboard =
-    await getFettMattisLeaderboard(currentYear);
-  expect(currentFettMattisLeaderboard).toHaveLength(2);
+  const currentFettmattisLeaderboard =
+    await getFettmattisLeaderboard(currentYear);
+  expect(currentFettmattisLeaderboard).toHaveLength(2);
 
-  const currentFettMattisLeader = expectDefined(
-    currentFettMattisLeaderboard[0],
-    "Expected Ada to lead the current year FettMattis leaderboard.",
+  const currentFettmattisLeader = expectDefined(
+    currentFettmattisLeaderboard[0],
+    "Expected Ada to lead the current year Fettmattis leaderboard.",
   );
 
-  expect(currentFettMattisLeader).toMatchObject({
+  expect(currentFettmattisLeader).toMatchObject({
     player: { displayName: "Ada" },
-    fettMattisCount: 1,
+    fettmattisCount: 1,
     rank: 1,
   });
 
-  const allTimeFettMattisLeaderboard = await getFettMattisLeaderboard(null);
-  expect(allTimeFettMattisLeaderboard).toHaveLength(2);
+  const allTimeFettmattisLeaderboard = await getFettmattisLeaderboard(null);
+  expect(allTimeFettmattisLeaderboard).toHaveLength(2);
 
-  const allTimeFettMattisLeader = expectDefined(
-    allTimeFettMattisLeaderboard[0],
-    "Expected Ada to lead the all-time FettMattis leaderboard.",
+  const allTimeFettmattisLeader = expectDefined(
+    allTimeFettmattisLeaderboard[0],
+    "Expected Ada to lead the all-time Fettmattis leaderboard.",
   );
 
-  expect(allTimeFettMattisLeader).toMatchObject({
+  expect(allTimeFettmattisLeader).toMatchObject({
     player: { displayName: "Ada" },
-    fettMattisCount: 2,
+    fettmattisCount: 2,
     rank: 1,
   });
 });

--- a/src/lib/__tests__/leaderboard.test.ts
+++ b/src/lib/__tests__/leaderboard.test.ts
@@ -26,14 +26,14 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: [
           {
-            player: { id: "player-1", display_name: "Alice" },
+            player: { id: "player-1", display_name: "Alice", active: true },
             participation_count: 10,
             loss_count: 3,
             loss_percentage: 30,
             rank: 1,
           },
           {
-            player: { id: "player-2", display_name: "Bob" },
+            player: { id: "player-2", display_name: "Bob", active: true },
             participation_count: 8,
             loss_count: 5,
             loss_percentage: 62.5,
@@ -75,7 +75,7 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: [
           {
-            player: { id: "player-1", display_name: "Charlie" },
+            player: { id: "player-1", display_name: "Charlie", active: true },
             participation_count: 5,
             loss_count: 2,
             loss_percentage: 40,
@@ -98,14 +98,14 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: [
           {
-            player: { id: "player-1", display_name: "Alice" },
+            player: { id: "player-1", display_name: "Alice", active: true },
             participation_count: 10,
             loss_count: 3,
             loss_percentage: 30,
             rank: null,
           },
           {
-            player: { id: "player-2", display_name: "Bob" },
+            player: { id: "player-2", display_name: "Bob", active: true },
             participation_count: 8,
             loss_count: 5,
             loss_percentage: 62.5,
@@ -126,7 +126,12 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: undefined,
         response: new Response(),
-        error: { message: "Not found" },
+        error: {
+          type: "about:blank",
+          title: "Not found",
+          status: 404,
+          detail: "Not found",
+        },
       });
 
       await expect(getRegularLeaderboard("all")).rejects.toThrow(
@@ -140,12 +145,12 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: [
           {
-            player: { id: "player-1", display_name: "Alice" },
+            player: { id: "player-1", display_name: "Alice", active: true },
             fettmattis_count: 5,
             rank: 1,
           },
           {
-            player: { id: "player-2", display_name: "Bob" },
+            player: { id: "player-2", display_name: "Bob", active: true },
             fettmattis_count: 3,
             rank: 2,
           },
@@ -184,7 +189,7 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: [
           {
-            player: { id: "player-1", display_name: "Charlie" },
+            player: { id: "player-1", display_name: "Charlie", active: true },
             fettmattis_count: 2,
             rank: 1,
           },
@@ -208,12 +213,12 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: [
           {
-            player: { id: "player-1", display_name: "Alice" },
+            player: { id: "player-1", display_name: "Alice", active: true },
             fettmattis_count: 5,
             rank: null,
           },
           {
-            player: { id: "player-2", display_name: "Bob" },
+            player: { id: "player-2", display_name: "Bob", active: true },
             fettmattis_count: 3,
             rank: null,
           },
@@ -232,7 +237,12 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: undefined,
         response: new Response(),
-        error: { message: "Not found" },
+        error: {
+          type: "about:blank",
+          title: "Not found",
+          status: 404,
+          detail: "Not found",
+        },
       });
 
       await expect(getFettmattisLeaderboard("all")).rejects.toThrow(
@@ -262,7 +272,12 @@ describe("leaderboard", () => {
       mockApiClient.GET.mockResolvedValueOnce({
         data: undefined,
         response: new Response(),
-        error: { message: "Not found" },
+        error: {
+          type: "about:blank",
+          title: "Not found",
+          status: 404,
+          detail: "Not found",
+        },
       });
 
       await expect(getLeaderboardSeasons()).rejects.toThrow(

--- a/src/lib/api/__tests__/fettmattis-client.test.ts
+++ b/src/lib/api/__tests__/fettmattis-client.test.ts
@@ -11,12 +11,12 @@ vi.mock("@/lib/api/client", () => ({
 
 import { apiClient, problemToError } from "@/lib/api/client";
 import {
-  createFettMattis,
-  createFettMattisListQueryKey,
-  fetchFettMattis,
-  revokeFettMattis,
+  createFettmattis,
+  createFettmattisListQueryKey,
+  fetchFettmattis,
+  revokeFettmattis,
 } from "@/lib/api/fettmattis-client";
-import type { FettMattis, FettMattisCreate } from "@/lib/api/schemas";
+import type { Fettmattis, FettmattisCreate } from "@/lib/api/schemas";
 
 const mockApiClient = vi.mocked(apiClient);
 const mockProblemToError = vi.mocked(problemToError);
@@ -29,20 +29,20 @@ beforeEach(() => {
 
 describe("fettmattis-client", () => {
   test("creates stable list query keys", () => {
-    expect(createFettMattisListQueryKey()).toEqual([
+    expect(createFettmattisListQueryKey()).toEqual([
       "fettmattis",
       "list",
       "default",
     ]);
-    expect(createFettMattisListQueryKey(10)).toEqual([
+    expect(createFettmattisListQueryKey(10)).toEqual([
       "fettmattis",
       "list",
       10,
     ]);
   });
 
-  test("fetchFettMattis returns data", async () => {
-    const entries: FettMattis[] = [
+  test("fetchFettmattis returns data", async () => {
+    const entries: Fettmattis[] = [
       {
         id: "00000000-0000-4000-8000-000000000011",
         created_at: new Date().toISOString(),
@@ -56,7 +56,7 @@ describe("fettmattis-client", () => {
       error: undefined,
     });
 
-    const result = await fetchFettMattis();
+    const result = await fetchFettmattis();
 
     expect(mockApiClient.GET).toHaveBeenCalledWith("/fettmattis", {
       params: {
@@ -66,14 +66,14 @@ describe("fettmattis-client", () => {
     expect(result).toEqual(entries);
   });
 
-  test("fetchFettMattis includes limit", async () => {
+  test("fetchFettmattis includes limit", async () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: [],
       response: new Response(),
       error: undefined,
     });
 
-    await fetchFettMattis({ limit: 2 });
+    await fetchFettmattis({ limit: 2 });
 
     expect(mockApiClient.GET).toHaveBeenCalledWith("/fettmattis", {
       params: {
@@ -82,20 +82,20 @@ describe("fettmattis-client", () => {
     });
   });
 
-  test("fetchFettMattis throws when data is missing", async () => {
+  test("fetchFettmattis throws when data is missing", async () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: undefined,
       response: new Response(),
       error: { detail: "Missing" },
     });
 
-    await expect(fetchFettMattis()).rejects.toThrow(
-      "Vi mottok et ugyldig svar da FettMattis-listen ble lastet.",
+    await expect(fetchFettmattis()).rejects.toThrow(
+      "Vi mottok et ugyldig svar da Fettmattis-listen ble lastet.",
     );
   });
 
-  test("createFettMattis posts validated payload", async () => {
-    const payload: FettMattisCreate = {
+  test("createFettmattis posts validated payload", async () => {
+    const payload: FettmattisCreate = {
       player_id: PLAYER_ID,
       round_id: "00000000-0000-4000-8000-000000000022",
     };
@@ -106,7 +106,7 @@ describe("fettmattis-client", () => {
       error: undefined,
     });
 
-    await createFettMattis(payload);
+    await createFettmattis(payload);
 
     expect(mockApiClient.POST).toHaveBeenCalledWith("/fettmattis", {
       body: payload,
@@ -117,8 +117,8 @@ describe("fettmattis-client", () => {
     });
   });
 
-  test("createFettMattis surfaces API errors", async () => {
-    const payload: FettMattisCreate = {
+  test("createFettmattis surfaces API errors", async () => {
+    const payload: FettmattisCreate = {
       player_id: PLAYER_ID,
     };
     const apiError = {
@@ -134,7 +134,7 @@ describe("fettmattis-client", () => {
       error: apiError,
     });
 
-    await expect(createFettMattis(payload)).rejects.toThrow(
+    await expect(createFettmattis(payload)).rejects.toThrow(
       "Kunne ikke tildele en Fettmattis.",
     );
     expect(mockProblemToError).toHaveBeenCalledWith(
@@ -143,14 +143,14 @@ describe("fettmattis-client", () => {
     );
   });
 
-  test("revokeFettMattis sends path params", async () => {
+  test("revokeFettmattis sends path params", async () => {
     mockApiClient.DELETE.mockResolvedValueOnce({
       data: undefined,
       response: new Response(),
       error: undefined,
     });
 
-    await revokeFettMattis("fett-1");
+    await revokeFettmattis("fett-1");
 
     expect(mockApiClient.DELETE).toHaveBeenCalledWith(
       "/fettmattis/{fettmattisId}",
@@ -165,7 +165,7 @@ describe("fettmattis-client", () => {
     );
   });
 
-  test("revokeFettMattis surfaces API errors", async () => {
+  test("revokeFettmattis surfaces API errors", async () => {
     const apiError = {
       type: "about:blank",
       title: "Not Found",
@@ -179,7 +179,7 @@ describe("fettmattis-client", () => {
       error: apiError,
     });
 
-    await expect(revokeFettMattis("fett-2")).rejects.toThrow(
+    await expect(revokeFettmattis("fett-2")).rejects.toThrow(
       "Kunne ikke slette Fettmattis.",
     );
     expect(mockProblemToError).toHaveBeenCalledWith(

--- a/src/lib/api/__tests__/fettmattis-client.test.ts
+++ b/src/lib/api/__tests__/fettmattis-client.test.ts
@@ -86,7 +86,12 @@ describe("fettmattis-client", () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: undefined,
       response: new Response(),
-      error: { detail: "Missing" },
+      error: {
+        type: "about:blank",
+        title: "Missing",
+        status: 400,
+        detail: "Missing",
+      },
     });
 
     await expect(fetchFettmattis()).rejects.toThrow(

--- a/src/lib/api/__tests__/players-client.test.ts
+++ b/src/lib/api/__tests__/players-client.test.ts
@@ -58,7 +58,12 @@ describe("players-client", () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: undefined,
       response: new Response(),
-      error: { detail: "Missing" },
+      error: {
+        type: "about:blank",
+        title: "Missing",
+        status: 400,
+        detail: "Missing",
+      },
     });
 
     await expect(fetchPlayers()).rejects.toThrow(

--- a/src/lib/api/__tests__/response-helpers.test.ts
+++ b/src/lib/api/__tests__/response-helpers.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
 
 import {
-  toFettMattisResponse,
+  toFettmattisResponse,
   toPlayerResponse,
   toRoundResponse,
 } from "@/lib/api/response-helpers";
 import type {
-  FettMattisRecord,
+  FettmattisRecord,
   RoundParticipantRecord,
   RoundRecord,
 } from "@/lib/db-client";
@@ -111,9 +111,9 @@ describe("toRoundResponse", () => {
   });
 });
 
-describe("toFettMattisResponse", () => {
+describe("toFettmattisResponse", () => {
   test("transforms fettmattis record with round_id", () => {
-    const record: FettMattisRecord = {
+    const record: FettmattisRecord = {
       id: "fm-123",
       player: { id: "p1", displayName: "Winner", active: true },
       createdAt: new Date("2025-03-10T12:00:00Z"),
@@ -122,7 +122,7 @@ describe("toFettMattisResponse", () => {
       roundId: "round-abc",
     };
 
-    const result = toFettMattisResponse(record);
+    const result = toFettmattisResponse(record);
 
     expect(result).toEqual({
       id: "fm-123",
@@ -133,7 +133,7 @@ describe("toFettMattisResponse", () => {
   });
 
   test("transforms fettmattis record without round_id", () => {
-    const record: FettMattisRecord = {
+    const record: FettmattisRecord = {
       id: "fm-456",
       player: { id: "p2", displayName: "Another Winner", active: true },
       createdAt: new Date("2025-04-15T09:30:00Z"),
@@ -142,7 +142,7 @@ describe("toFettMattisResponse", () => {
       roundId: null,
     };
 
-    const result = toFettMattisResponse(record);
+    const result = toFettmattisResponse(record);
 
     expect(result).toEqual({
       id: "fm-456",
@@ -153,7 +153,7 @@ describe("toFettMattisResponse", () => {
   });
 
   test("transforms fettmattis record with undefined round_id", () => {
-    const record: FettMattisRecord = {
+    const record: FettmattisRecord = {
       id: "fm-789",
       player: { id: "p3", displayName: "Third Player", active: false },
       createdAt: new Date("2025-05-20T18:45:00Z"),
@@ -162,7 +162,7 @@ describe("toFettMattisResponse", () => {
       roundId: undefined,
     };
 
-    const result = toFettMattisResponse(record);
+    const result = toFettmattisResponse(record);
 
     expect(result.round_id).toBeNull();
   });

--- a/src/lib/api/__tests__/rounds-client.test.ts
+++ b/src/lib/api/__tests__/rounds-client.test.ts
@@ -86,7 +86,12 @@ describe("rounds-client", () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: undefined,
       response: new Response(),
-      error: { detail: "Missing" },
+      error: {
+        type: "about:blank",
+        title: "Missing",
+        status: 400,
+        detail: "Missing",
+      },
     });
 
     await expect(fetchRounds()).rejects.toThrow(
@@ -111,7 +116,12 @@ describe("rounds-client", () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: undefined,
       response: new Response(),
-      error: { detail: "Missing" },
+      error: {
+        type: "about:blank",
+        title: "Missing",
+        status: 400,
+        detail: "Missing",
+      },
     });
 
     await expect(fetchLatestRound()).rejects.toThrow(

--- a/src/lib/api/fettmattis-client.ts
+++ b/src/lib/api/fettmattis-client.ts
@@ -2,22 +2,22 @@ import type { QueryKey } from "@tanstack/react-query";
 
 import { apiClient, problemToError } from "@/lib/api/client";
 import {
-  type FettMattis,
-  type FettMattisCreate,
-  FettMattisCreateSchema,
+  type Fettmattis,
+  type FettmattisCreate,
+  FettmattisCreateSchema,
 } from "@/lib/api/schemas";
 
-export function createFettMattisListQueryKey(limit?: number) {
+export function createFettmattisListQueryKey(limit?: number) {
   return ["fettmattis", "list", limit ?? "default"] as const satisfies QueryKey;
 }
 
-interface FetchFettMattisOptions {
+interface FetchFettmattisOptions {
   limit?: number;
 }
 
-export async function fetchFettMattis(
-  options: FetchFettMattisOptions = {},
-): Promise<FettMattis[]> {
+export async function fetchFettmattis(
+  options: FetchFettmattisOptions = {},
+): Promise<Fettmattis[]> {
   const { data } = await apiClient.GET("/fettmattis", {
     params: {
       query: options.limit ? { limit: options.limit } : undefined,
@@ -26,19 +26,19 @@ export async function fetchFettMattis(
 
   if (!data) {
     throw new Error(
-      "Vi mottok et ugyldig svar da FettMattis-listen ble lastet.",
+      "Vi mottok et ugyldig svar da Fettmattis-listen ble lastet.",
     );
   }
 
   return data;
 }
 
-export type { FettMattis } from "@/lib/api/schemas";
+export type { Fettmattis } from "@/lib/api/schemas";
 
-export async function createFettMattis(
-  payload: FettMattisCreate,
+export async function createFettmattis(
+  payload: FettmattisCreate,
 ): Promise<void> {
-  const parsedPayload = FettMattisCreateSchema.parse(payload);
+  const parsedPayload = FettmattisCreateSchema.parse(payload);
   const { error } = await apiClient.POST("/fettmattis", {
     body: parsedPayload,
     headers: {
@@ -52,11 +52,11 @@ export async function createFettMattis(
   }
 }
 
-export async function revokeFettMattis(fettMattisId: string): Promise<void> {
+export async function revokeFettmattis(fettmattisId: string): Promise<void> {
   const { error } = await apiClient.DELETE("/fettmattis/{fettmattisId}", {
     params: {
       path: {
-        fettmattisId: fettMattisId,
+        fettmattisId: fettmattisId,
       },
     },
     credentials: "include",

--- a/src/lib/api/generated.ts
+++ b/src/lib/api/generated.ts
@@ -71,10 +71,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** List Players */
+    /**
+     * List Players
+     * @description Returns all players, ordered by display name.
+     */
     get: operations["listPlayers"];
     put?: never;
-    /** Create Player */
+    /**
+     * Create Player
+     * @description Creates a new player in the roster.
+     */
     post: operations["createPlayer"];
     delete?: never;
     options?: never;
@@ -89,9 +95,15 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Player Details */
+    /**
+     * Get Player Details
+     * @description Returns details for a single player.
+     */
     get: operations["getPlayer"];
-    /** Update Player */
+    /**
+     * Update Player
+     * @description Updates player profile fields and status.
+     */
     put: operations["updatePlayer"];
     post?: never;
     delete?: never;
@@ -107,10 +119,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** List Rounds */
+    /**
+     * List Rounds
+     * @description Returns recent rounds, optionally limited by query parameter.
+     */
     get: operations["listRounds"];
     put?: never;
-    /** Record a Round */
+    /**
+     * Record a Round
+     * @description Records a completed round and updates leaderboards.
+     */
     post: operations["createRound"];
     delete?: never;
     options?: never;
@@ -145,12 +163,21 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Round Details */
+    /**
+     * Get Round Details
+     * @description Returns the details of a specific round.
+     */
     get: operations["getRound"];
-    /** Edit a Round (within 24h) */
+    /**
+     * Edit a Round (within 24h)
+     * @description Updates round participants or the recorded loser within the edit window.
+     */
     put: operations["updateRound"];
     post?: never;
-    /** Soft Delete a Round (within 24h) */
+    /**
+     * Soft Delete a Round (within 24h)
+     * @description Soft-deletes a round and removes it from leaderboards.
+     */
     delete: operations["deleteRound"];
     options?: never;
     head?: never;
@@ -164,10 +191,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** List FettMattis Entries */
+    /**
+     * List Fettmattis Entries
+     * @description Returns recent Fettmattis awards.
+     */
     get: operations["listFettmattis"];
     put?: never;
-    /** Create FettMattis */
+    /**
+     * Create Fettmattis
+     * @description Grants a Fettmattis award to a player.
+     */
     post: operations["createFettmattis"];
     delete?: never;
     options?: never;
@@ -185,7 +218,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Delete FettMattis (within 24h) */
+    /**
+     * Delete Fettmattis (within 24h)
+     * @description Revokes a Fettmattis award within the edit window.
+     */
     delete: operations["deleteFettmattis"];
     options?: never;
     head?: never;
@@ -199,7 +235,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Regular Leaderboard */
+    /**
+     * Get Regular Leaderboard
+     * @description Returns leaderboard standings for regular play.
+     */
     get: operations["getRegularLeaderboard"];
     put?: never;
     post?: never;
@@ -216,7 +255,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Fettmattis Leaderboard */
+    /**
+     * Get Fettmattis Leaderboard
+     * @description Returns leaderboard standings for Fettmattis awards.
+     */
     get: operations["getFettmattisLeaderboard"];
     put?: never;
     post?: never;
@@ -233,7 +275,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** List Available Leaderboard Seasons */
+    /**
+     * List Available Leaderboard Seasons
+     * @description Returns the list of seasons with available leaderboard data.
+     */
     get: operations["listLeaderboardSeasons"];
     put?: never;
     post?: never;
@@ -374,7 +419,7 @@ export interface components {
        */
       loser_id?: string;
     };
-    FettMattis: {
+    Fettmattis: {
       /**
        * Format: uuid
        * @description UUID v7, time-ordered identifier.
@@ -389,7 +434,7 @@ export interface components {
       /** Format: date-time */
       created_at: string;
     };
-    FettMattisCreate: {
+    FettmattisCreate: {
       /**
        * Format: uuid
        * @description UUID v7, time-ordered identifier.
@@ -803,7 +848,7 @@ export interface operations {
   listFettmattis: {
     parameters: {
       query?: {
-        /** @description Limit the number of FettMattis entries returned. Defaults to 20 when omitted. */
+        /** @description Limit the number of Fettmattis entries returned. Defaults to 20 when omitted. */
         limit?: number;
       };
       header?: never;
@@ -812,13 +857,13 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description A list of recent FettMattis entries. */
+      /** @description A list of recent Fettmattis entries. */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["FettMattis"][];
+          "application/json": components["schemas"]["Fettmattis"][];
         };
       };
     };
@@ -832,17 +877,17 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["FettMattisCreate"];
+        "application/json": components["schemas"]["FettmattisCreate"];
       };
     };
     responses: {
-      /** @description FettMattis created successfully. */
+      /** @description Fettmattis created successfully. */
       201: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["FettMattis"];
+          "application/json": components["schemas"]["Fettmattis"];
         };
       };
       400: components["responses"]["BadRequest"];
@@ -861,7 +906,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description FettMattis revoked successfully. */
+      /** @description Fettmattis revoked successfully. */
       204: {
         headers: {
           [name: string]: unknown;

--- a/src/lib/api/generated.ts
+++ b/src/lib/api/generated.ts
@@ -448,15 +448,20 @@ export interface components {
     };
     RegularLeaderboardItem: {
       player: components["schemas"]["Player"];
-      rank: number;
+      /** Format: int32 */
+      rank: number | null;
       /** Format: float */
       loss_percentage: number;
+      /** Format: int32 */
       participation_count: number;
+      /** Format: int32 */
       loss_count: number;
     };
     FettmattisLeaderboardItem: {
       player: components["schemas"]["Player"];
-      rank: number;
+      /** Format: int32 */
+      rank: number | null;
+      /** Format: int32 */
       fettmattis_count: number;
     };
     LeaderboardSeasonsResponse: {
@@ -471,6 +476,7 @@ export interface components {
        */
       type: string;
       title: string;
+      /** Format: int32 */
       status: number;
       detail?: string;
       /** Format: uri */
@@ -481,6 +487,10 @@ export interface components {
     /** @description The request body is invalid. */
     BadRequest: {
       headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
         [name: string]: unknown;
       };
       content: {
@@ -490,6 +500,10 @@ export interface components {
     /** @description Authentication is required for this operation. */
     Unauthorized: {
       headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
         [name: string]: unknown;
       };
       content: {
@@ -499,6 +513,10 @@ export interface components {
     /** @description The requested resource was not found. */
     NotFound: {
       headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
         [name: string]: unknown;
       };
       content: {
@@ -508,6 +526,10 @@ export interface components {
     /** @description The action is forbidden, e.g., editing an item outside the 24h window. */
     Forbidden: {
       headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
         [name: string]: unknown;
       };
       content: {
@@ -517,6 +539,37 @@ export interface components {
     /** @description The resource already exists or the request conflicts with the current state. */
     Conflict: {
       headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
+        [name: string]: unknown;
+      };
+      content: {
+        "application/problem+json": components["schemas"]["Problem"];
+      };
+    };
+    /** @description The client has sent too many requests in a given amount of time. */
+    TooManyRequests: {
+      headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
+        "Retry-After": components["headers"]["Retry-After"];
+        [name: string]: unknown;
+      };
+      content: {
+        "application/problem+json": components["schemas"]["Problem"];
+      };
+    };
+    /** @description The server encountered an unexpected error. */
+    InternalServerError: {
+      headers: {
+        "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+        "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+        "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+        "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
         [name: string]: unknown;
       };
       content: {
@@ -526,7 +579,18 @@ export interface components {
   };
   parameters: never;
   requestBodies: never;
-  headers: never;
+  headers: {
+    /** @description Allowed origin for cross-origin requests. */
+    "Access-Control-Allow-Origin": string;
+    /** @description The maximum number of requests permitted in the current window. */
+    "RateLimit-Limit": number;
+    /** @description The number of remaining requests in the current window. */
+    "RateLimit-Remaining": number;
+    /** @description Seconds remaining until the rate limit window resets. */
+    "RateLimit-Reset": number;
+    /** @description Seconds to wait before making a new request. */
+    "Retry-After": number;
+  };
   pathItems: never;
 }
 export type $defs = Record<string, never>;
@@ -543,13 +607,20 @@ export interface operations {
       /** @description The current session details or null when no session is available. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["AuthSession"] | null;
         };
       };
+      400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   signInWithEmail: {
@@ -568,6 +639,10 @@ export interface operations {
       /** @description Session token and user details for the authenticated user. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -577,6 +652,8 @@ export interface operations {
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
       403: components["responses"]["Forbidden"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   signOut: {
@@ -591,6 +668,10 @@ export interface operations {
       /** @description Confirmation that the session was terminated. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -598,6 +679,9 @@ export interface operations {
         };
       };
       400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   listPlayers: {
@@ -612,12 +696,20 @@ export interface operations {
       /** @description A list of players. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["Player"][];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   createPlayer: {
@@ -636,6 +728,10 @@ export interface operations {
       /** @description Player created successfully. */
       201: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -645,6 +741,8 @@ export interface operations {
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
       409: components["responses"]["Conflict"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   getPlayer: {
@@ -661,13 +759,21 @@ export interface operations {
       /** @description Player details. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["Player"];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
       404: components["responses"]["NotFound"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   updatePlayer: {
@@ -688,6 +794,10 @@ export interface operations {
       /** @description Player updated successfully. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -697,6 +807,8 @@ export interface operations {
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
       404: components["responses"]["NotFound"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   listRounds: {
@@ -714,12 +826,20 @@ export interface operations {
       /** @description A list of recent rounds. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["Round"][];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   createRound: {
@@ -738,6 +858,10 @@ export interface operations {
       /** @description Round created successfully. */
       201: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -746,6 +870,8 @@ export interface operations {
       };
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   getLatestRound: {
@@ -760,12 +886,20 @@ export interface operations {
       /** @description The most recent round or null when no rounds exist. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["Round"] | null;
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   getRound: {
@@ -782,13 +916,21 @@ export interface operations {
       /** @description Round details. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["Round"];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
       404: components["responses"]["NotFound"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   updateRound: {
@@ -809,6 +951,10 @@ export interface operations {
       /** @description Round updated successfully. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -820,6 +966,8 @@ export interface operations {
       403: components["responses"]["Forbidden"];
       404: components["responses"]["NotFound"];
       409: components["responses"]["Conflict"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   deleteRound: {
@@ -836,13 +984,20 @@ export interface operations {
       /** @description Round deleted successfully. */
       204: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content?: never;
       };
+      400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
       403: components["responses"]["Forbidden"];
       404: components["responses"]["NotFound"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   listFettmattis: {
@@ -860,12 +1015,20 @@ export interface operations {
       /** @description A list of recent Fettmattis entries. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["Fettmattis"][];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   createFettmattis: {
@@ -884,6 +1047,10 @@ export interface operations {
       /** @description Fettmattis created successfully. */
       201: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
@@ -893,6 +1060,8 @@ export interface operations {
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
       409: components["responses"]["Conflict"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   deleteFettmattis: {
@@ -909,13 +1078,20 @@ export interface operations {
       /** @description Fettmattis revoked successfully. */
       204: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content?: never;
       };
+      400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthorized"];
       403: components["responses"]["Forbidden"];
       404: components["responses"]["NotFound"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   getRegularLeaderboard: {
@@ -933,12 +1109,20 @@ export interface operations {
       /** @description The regular season leaderboard. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["RegularLeaderboardItem"][];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   getFettmattisLeaderboard: {
@@ -956,12 +1140,20 @@ export interface operations {
       /** @description The Fettmattis leaderboard. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["FettmattisLeaderboardItem"][];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
   listLeaderboardSeasons: {
@@ -976,12 +1168,20 @@ export interface operations {
       /** @description Available leaderboard seasons. */
       200: {
         headers: {
+          "RateLimit-Limit": components["headers"]["RateLimit-Limit"];
+          "RateLimit-Remaining": components["headers"]["RateLimit-Remaining"];
+          "RateLimit-Reset": components["headers"]["RateLimit-Reset"];
+          "Access-Control-Allow-Origin": components["headers"]["Access-Control-Allow-Origin"];
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["LeaderboardSeasonsResponse"];
         };
       };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      429: components["responses"]["TooManyRequests"];
+      500: components["responses"]["InternalServerError"];
     };
   };
 }

--- a/src/lib/api/response-helpers.ts
+++ b/src/lib/api/response-helpers.ts
@@ -1,11 +1,11 @@
 import type {
-  FettMattisRecord,
+  FettmattisRecord,
   PlayerRecord,
   RoundParticipantRecord,
   RoundRecord,
 } from "@/lib/db-client";
 
-import type { FettMattis, Player, Round } from "./schemas";
+import type { Fettmattis, Player, Round } from "./schemas";
 
 export type PlayerResponseInput =
   | Pick<PlayerRecord, "id" | "displayName" | "active">
@@ -14,7 +14,7 @@ export type PlayerResponseInput =
 export type PlayerResponse = Player;
 
 export type RoundResponse = Round;
-export type FettMattisResponse = FettMattis;
+export type FettmattisResponse = Fettmattis;
 
 export function toPlayerResponse(player: PlayerResponseInput): PlayerResponse {
   return {
@@ -33,9 +33,9 @@ export function toRoundResponse(round: RoundRecord): RoundResponse {
   };
 }
 
-export function toFettMattisResponse(
-  record: FettMattisRecord,
-): FettMattisResponse {
+export function toFettmattisResponse(
+  record: FettmattisRecord,
+): FettmattisResponse {
   return {
     id: record.id,
     player: toPlayerResponse(record.player),

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -123,16 +123,16 @@ export const ListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
 
-// --- FettMattis Schemas ---
+// --- Fettmattis Schemas ---
 
-export const FettMattisSchema = z.object({
+export const FettmattisSchema = z.object({
   id: uuidSchema,
   player: PlayerSchema,
   round_id: uuidSchema.nullish(),
   created_at: isoDateTimeSchema,
 });
 
-export const FettMattisCreateSchema = z.object({
+export const FettmattisCreateSchema = z.object({
   player_id: uuidSchema,
   round_id: uuidSchema.optional(),
 });
@@ -199,8 +199,8 @@ export type LeaderboardSeasonsResponse =
 export type Round = ApiSchemas["Round"];
 export type RoundCreate = ApiSchemas["RoundCreate"];
 export type RoundUpdate = ApiSchemas["RoundUpdate"];
-export type FettMattis = ApiSchemas["FettMattis"];
-export type FettMattisCreate = ApiSchemas["FettMattisCreate"];
+export type Fettmattis = ApiSchemas["Fettmattis"];
+export type FettmattisCreate = ApiSchemas["FettmattisCreate"];
 export type RegularLeaderboardItem = ApiSchemas["RegularLeaderboardItem"];
 export type FettmattisLeaderboardItem = ApiSchemas["FettmattisLeaderboardItem"];
 export type ProblemDetails = ApiSchemas["Problem"];

--- a/src/lib/db-client.ts
+++ b/src/lib/db-client.ts
@@ -40,7 +40,7 @@ export interface RoundRecord {
   loser: RoundParticipantRecord;
 }
 
-export interface FettMattisRecord {
+export interface FettmattisRecord {
   id: string;
   player: RoundParticipantRecord;
   createdAt: Date;
@@ -71,7 +71,7 @@ export interface UpdateRoundInput {
   loserId?: string;
 }
 
-export interface CreateFettMattisInput {
+export interface CreateFettmattisInput {
   playerId: string;
   createdBy: string;
 }
@@ -442,9 +442,9 @@ export async function listRecentRounds(
   return loadedRounds.filter((round): round is RoundRecord => round !== null);
 }
 
-export async function listRecentFettMattis(
+export async function listRecentFettmattis(
   options: RecentListOptions = {},
-): Promise<FettMattisRecord[]> {
+): Promise<FettmattisRecord[]> {
   const listLimit = resolveListLimit(options.limit);
 
   const rows = await db
@@ -563,9 +563,9 @@ export async function deleteRound(roundId: string): Promise<void> {
   });
 }
 
-export async function createFettMattis(
-  input: CreateFettMattisInput,
-): Promise<FettMattisRecord> {
+export async function createFettmattis(
+  input: CreateFettmattisInput,
+): Promise<FettmattisRecord> {
   return db.transaction(async (tx) => {
     await ensureUser(tx, input.createdBy);
 
@@ -602,7 +602,7 @@ export async function createFettMattis(
   });
 }
 
-export async function revokeFettMattis(fettmattisId: string): Promise<void> {
+export async function revokeFettmattis(fettmattisId: string): Promise<void> {
   await db.transaction(async (tx) => {
     const [row] = await tx
       .select()
@@ -618,7 +618,7 @@ export async function revokeFettMattis(fettmattisId: string): Promise<void> {
       return;
     }
 
-    assertEditWindow(row.createdAt, "FettMattis");
+    assertEditWindow(row.createdAt, "Fettmattis");
 
     await tx
       .update(fettmattis)
@@ -635,9 +635,9 @@ export interface RegularLeaderboardEntry {
   player: RoundParticipantRecord;
 }
 
-export interface FettMattisLeaderboardEntry {
+export interface FettmattisLeaderboardEntry {
   rank: number;
-  fettMattisCount: number;
+  fettmattisCount: number;
   player: RoundParticipantRecord;
 }
 
@@ -649,7 +649,7 @@ interface RegularLeaderboardRow extends Record<string, unknown> {
   loss_count: number;
 }
 
-interface FettMattisLeaderboardRow extends Record<string, unknown> {
+interface FettmattisLeaderboardRow extends Record<string, unknown> {
   player_id: string;
   display_name: string;
   active: boolean;
@@ -706,27 +706,27 @@ export async function getRegularLeaderboard(
   }));
 }
 
-export async function getFettMattisLeaderboard(
+export async function getFettmattisLeaderboard(
   year: number | null,
-): Promise<FettMattisLeaderboardEntry[]> {
-  const res = await db.execute<FettMattisLeaderboardRow>(
-    fettMattisLeaderboardQuery(year),
+): Promise<FettmattisLeaderboardEntry[]> {
+  const res = await db.execute<FettmattisLeaderboardRow>(
+    fettmattisLeaderboardQuery(year),
   );
 
   const leaderboard = res.rows
     .map(
-      (row): { player: RoundParticipantRecord; fettMattisCount: number } => ({
+      (row): { player: RoundParticipantRecord; fettmattisCount: number } => ({
         player: {
           id: row.player_id,
           displayName: row.display_name,
           active: row.active,
         },
-        fettMattisCount: row.fettmattis_count,
+        fettmattisCount: row.fettmattis_count,
       }),
     )
     .sort((a, b) => {
-      if (a.fettMattisCount !== b.fettMattisCount) {
-        return b.fettMattisCount - a.fettMattisCount;
+      if (a.fettmattisCount !== b.fettmattisCount) {
+        return b.fettmattisCount - a.fettmattisCount;
       }
       return a.player.displayName.localeCompare(b.player.displayName);
     });
@@ -826,7 +826,7 @@ function regularLeaderboardQuery(year: number | null) {
   `;
 }
 
-function fettMattisLeaderboardQuery(year: number | null): SQL {
+function fettmattisLeaderboardQuery(year: number | null): SQL {
   const yearFilter =
     typeof year === "number"
       ? sql`AND EXTRACT(YEAR FROM f.created_at) = ${year}`
@@ -848,7 +848,7 @@ function fettMattisLeaderboardQuery(year: number | null): SQL {
 
 export interface OverviewStats {
   totalRounds: number;
-  fettMattisMoments: number;
+  fettmattisMoments: number;
   activePlayers: number;
 }
 
@@ -858,7 +858,7 @@ export async function getOverviewStats(): Promise<OverviewStats> {
     .from(rounds)
     .where(isNull(rounds.deletedAt));
 
-  const [fettMattisEntry] = await db
+  const [fettmattisEntry] = await db
     .select({ count: sql<number>`cast(count(*) as int)` })
     .from(fettmattis)
     .where(isNull(fettmattis.revokedAt));
@@ -870,7 +870,7 @@ export async function getOverviewStats(): Promise<OverviewStats> {
 
   return {
     totalRounds: roundsEntry?.count ?? 0,
-    fettMattisMoments: fettMattisEntry?.count ?? 0,
+    fettmattisMoments: fettmattisEntry?.count ?? 0,
     activePlayers: playersEntry?.count ?? 0,
   };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -193,7 +193,7 @@ export const fettmattisRelations = relations(fettmattis, ({ one }) => ({
 export type User = typeof users.$inferSelect;
 export type Player = typeof players.$inferSelect;
 export type Round = typeof rounds.$inferSelect;
-export type FettMattis = typeof fettmattis.$inferSelect;
+export type Fettmattis = typeof fettmattis.$inferSelect;
 export type Account = typeof accounts.$inferSelect;
 export type Session = typeof sessions.$inferSelect;
 export type Verification = typeof verifications.$inferSelect;

--- a/src/scripts/migrate-from-mysql.ts
+++ b/src/scripts/migrate-from-mysql.ts
@@ -15,7 +15,7 @@ type PlayerInsertRow = typeof schema.players.$inferInsert;
 type RoundInsertRow = typeof schema.rounds.$inferInsert;
 type RoundLoserInsertRow = typeof schema.roundLoser.$inferInsert;
 type RoundParticipantInsertRow = typeof schema.roundParticipants.$inferInsert;
-type FettMattisInsertRow = typeof schema.fettmattis.$inferInsert;
+type FettmattisInsertRow = typeof schema.fettmattis.$inferInsert;
 
 type LegacyDateValue = Date | string | null;
 
@@ -162,7 +162,7 @@ async function fetchSourceData(pool: MySqlPool): Promise<SourceData> {
     `${players.length.toString()} players`,
     `${rounds.length.toString()} rounds`,
     `${playerRounds.length.toString()} round participations`,
-    `${fettRounds.length.toString()} FettMattis awards`,
+    `${fettRounds.length.toString()} Fettmattis awards`,
   ];
 
   writeInfo(messages.join(", "));
@@ -232,13 +232,13 @@ async function migrateData(
     warnings.push(...roundInsertData.warnings);
     await insertRounds(tx, roundInsertData);
 
-    const fettMattisInsert = buildFettMattisInsert(
+    const fettmattisInsert = buildFettmattisInsert(
       sourceData.fettRounds,
       playerIdMap,
       options,
     );
-    warnings.push(...fettMattisInsert.warnings);
-    await insertFettMattis(tx, fettMattisInsert.items);
+    warnings.push(...fettmattisInsert.warnings);
+    await insertFettmattis(tx, fettmattisInsert.items);
   });
 
   if (warnings.length > 0) {
@@ -471,23 +471,23 @@ async function insertRounds(
   }
 }
 
-interface FettMattisInsert {
-  items: FettMattisInsertRow[];
+interface FettmattisInsert {
+  items: FettmattisInsertRow[];
   warnings: string[];
 }
 
-function buildFettMattisInsert(
+function buildFettmattisInsert(
   rows: SourceFettRoundRow[],
   playerIdMap: Map<number, string>,
   options: MigrationOptions,
-): FettMattisInsert {
+): FettmattisInsert {
   const warnings: string[] = [];
 
-  const items: FettMattisInsertRow[] = rows
+  const items: FettmattisInsertRow[] = rows
     .map((row) => {
       if (row.loser_id === null) {
         warnings.push(
-          `Skipping FettMattis ${formatLegacyId(row.id)} because it has no associated player.`,
+          `Skipping Fettmattis ${formatLegacyId(row.id)} because it has no associated player.`,
         );
         return null;
       }
@@ -496,12 +496,12 @@ function buildFettMattisInsert(
 
       if (!playerId) {
         warnings.push(
-          `Skipping FettMattis ${formatLegacyId(row.id)} because player ${formatLegacyId(row.loser_id)} could not be resolved.`,
+          `Skipping Fettmattis ${formatLegacyId(row.id)} because player ${formatLegacyId(row.loser_id)} could not be resolved.`,
         );
         return null;
       }
 
-      const item: FettMattisInsertRow = {
+      const item: FettmattisInsertRow = {
         id: generateId(),
         playerId,
         createdBy: options.migrationUserId,
@@ -511,14 +511,14 @@ function buildFettMattisInsert(
 
       return item;
     })
-    .filter((value): value is FettMattisInsertRow => value !== null);
+    .filter((value): value is FettmattisInsertRow => value !== null);
 
   return { items, warnings };
 }
 
-async function insertFettMattis(
+async function insertFettmattis(
   tx: TargetDatabase,
-  items: FettMattisInsertRow[],
+  items: FettmattisInsertRow[],
 ): Promise<void> {
   if (items.length === 0) {
     return;

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -26,7 +26,7 @@ interface RoundSeed {
   createdBy: string;
 }
 
-interface FettMattisSeed {
+interface FettmattisSeed {
   id: string;
   player: string;
   round: string | null;
@@ -158,7 +158,7 @@ const roundSeeds: RoundSeed[] = [
   },
 ];
 
-const fettMattisSeeds: FettMattisSeed[] = [
+const fettmattisSeeds: FettmattisSeed[] = [
   // Last year fettmattis - for 24-hour deletion window test (no delete button)
   {
     id: "30000000-0000-4000-8000-000000000301",
@@ -182,7 +182,7 @@ const fettMattisSeeds: FettMattisSeed[] = [
     createdBy: devUserId,
   },
   // Current year fettmattis - for leaderboard visibility (uses explicit current year dates)
-  // T037 expects Astrid and Lina in the FettMattis table
+  // T037 expects Astrid and Lina in the Fettmattis table
   {
     id: "30000000-0000-4000-8000-000000000304",
     player: "astrid",
@@ -225,7 +225,7 @@ async function seed(): Promise<void> {
       );
       const players = await insertPlayers(tx);
       const rounds = await insertRounds(tx, players);
-      await insertFettMattis(tx, players, rounds);
+      await insertFettmattis(tx, players, rounds);
     });
 
     writeLine(process.stdout, "Database seed completed successfully.");
@@ -336,14 +336,14 @@ async function insertRounds(
   return roundsMap;
 }
 
-async function insertFettMattis(
+async function insertFettmattis(
   client: DbExecutor,
   players: Map<string, PlayerRecord>,
   rounds: Map<string, RoundRecord>,
 ): Promise<void> {
   writeLine(process.stdout, "Awarding Fettmattis records...");
 
-  for (const entry of fettMattisSeeds) {
+  for (const entry of fettmattisSeeds) {
     const player = players.get(entry.player);
     if (!player) {
       throw new Error(`Fettmattis player ${entry.player} not found.`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,5 @@
     "**/*.tsx",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
## Summary
- add OWASP Spectral + OWASP API Governance rulesets for linting
- tighten OpenAPI with standard error responses, rate-limit/CORS headers, and schema limits
- update tests + generated OpenAPI types; exclude build output from tsconfig

## Testing
- npm run spectral
- npx spectral lint openapi.yaml --fail-severity=warn
- npm run lint (warns about baseline-browser-mapping age)
- npm run tsc
- npm run test